### PR TITLE
Add optional flags to translate

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -6,7 +6,7 @@ from textwrap import dedent as wrap
 
 import config
 import discord
-from discord.ext import commands, tasks
+from discord.ext import commands, tasks, flags
 
 
 class Events(commands.Cog):
@@ -54,11 +54,10 @@ class Events(commands.Cog):
 
     @commands.Cog.listener()
     async def on_command_error(self, ctx, error):
-        ignored = (commands.CommandNotFound,
-                   commands.DisabledCommand, commands.TooManyArguments)
-        send_embed = (commands.MissingPermissions, discord.HTTPException,
-                      commands.NotOwner, commands.CheckFailure, commands.MissingRequiredArgument,
-                      commands.BadArgument, commands.BadUnionArgument)
+        ignored = (commands.CommandNotFound, commands.DisabledCommand, commands.TooManyArguments)
+        send_embed = (commands.MissingPermissions, discord.HTTPException, commands.NotOwner,
+                      commands.CheckFailure, commands.MissingRequiredArgument, commands.BadArgument,
+                      commands.BadUnionArgument, flags.ArgumentParsingError)
 
         errors = {
             commands.MissingPermissions: "You do not have permissions to run this command.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ googletrans
 parsedatetime
 aiohttp
 tweepy
+discord-flags


### PR DESCRIPTION
This adds optional --to and --from flags to the translate command. Used the discord-flags package for this, which i also added to requirements.txt. Also added flags.ArgumentParsingError to the error handler to be handled.