### PR TITLE
Improve fire command.

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -28,7 +28,9 @@ class Admin(commands.Cog):
         if staff_role not in member.roles or member.bot:
             return await ctx.send("That is a bot or not a staff member.")
         if member.id == ctx.author.id:
-            return await ctx.send(f"Please contact a fellow Admin if you want to resign from being staff at Blist. **{ctx.author}**")
+            atc = str(self.bot.main_guild.get_member(679118121943957504))
+            adu = str(self.bot.main_guild.get_member(712737377524777001)) if ctx.author.id != 712737377524777001 else atc
+            return await ctx.send(f"**{ctx.author.mention}**, i can't let you do that. Please contact {adu} if you want to resign from your staff position at Blist. ")
 
         msg = await ctx.send(f"**{ctx.author.name}**, do you really want to fire {member}? "
                              f"React with ✅ or ❌ in 30 seconds. **This action will remove __all__ staff privileges from {member}!**")

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -39,26 +39,22 @@ class Admin(commands.Cog):
             return u.id == ctx.author.id and r.message.channel.id == ctx.channel.id and \
                    str(r.emoji) in ["\U00002705", "\U0000274c"]
 
-        async def remove_reactions():
-            try:
-                await msg.clear_reactions()
-            except (discord.HTTPException, discord.Forbidden):  # ignore it.
-                # this should always work.
-                await msg.remove_reaction("\U00002705", ctx.guild.me)
-                await msg.remove_reaction("\U0000274c", ctx.guild.me)
-
         try:
             reaction, user = await self.bot.wait_for('reaction_add', check=check, timeout=30)
         except asyncio.TimeoutError:
-            await remove_reactions()
+            await msg.remove_reaction("\U00002705", ctx.guild.me)
+            await msg.remove_reaction("\U0000274c", ctx.guild.me)
             await msg.edit(content=f"~~{msg.content}~~ i guess not, cancelled.")
             return
         else:
             if str(reaction.emoji) == "\U00002705":
-                await remove_reactions()
+                await msg.remove_reaction("\U00002705", ctx.guild.me)
+                await msg.remove_reaction("\U0000274c", ctx.guild.me)
+                await msg.edit(content = f"~~{msg.content}~~ You reacted with ✅:")
                 pass
             if str(reaction.emoji) == "\U0000274c":
-                await remove_reactions()
+                await msg.remove_reaction("\U00002705", ctx.guild.me)
+                await msg.remove_reaction("\U0000274c", ctx.guild.me)
                 await msg.edit(content=f"~~{msg.content}~~ okay, cancelled.")
                 return
 
@@ -90,10 +86,7 @@ class Admin(commands.Cog):
 
         join_list = "\n".join(success_text)
         await self.bot.mod_pool.execute("DELETE FROM staff WHERE userid = $1", member.id)
-        try:
-            await msg.delete()
-        except discord.NotFound:  # maybe someone decided to the message..
-            pass
+
         await ctx.send(f"Successfully fired {member} ({member.id}).\n\n{join_list}")
 
     @commands.has_permissions(administrator = True)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -38,8 +38,7 @@ class Admin(commands.Cog):
         await msg.add_reaction("\U0000274c")
 
         def check(r, u):
-            return u.id == ctx.author.id and r.message.channel.id == ctx.channel.id and \
-                   str(r.emoji) in ["\U00002705", "\U0000274c"]
+            return u.id == ctx.author.id and r.message.channel.id == ctx.channel.id and str(r.emoji) in ["\U00002705", "\U0000274c"]
 
         try:
             reaction, user = await self.bot.wait_for('reaction_add', check=check, timeout=30)
@@ -88,7 +87,6 @@ class Admin(commands.Cog):
 
         join_list = "\n".join(success_text)
         await self.bot.mod_pool.execute("DELETE FROM staff WHERE userid = $1", member.id)
-
         await ctx.send(f"Successfully fired {member} ({member.id}).\n\n{join_list}")
 
     @commands.has_permissions(administrator = True)


### PR DESCRIPTION
First i have to apologize for the mistakes I made in my first pr for this command, sowwy.

Now.. this adds:

- Prevent a admin from firing themself, this will send a (nice) message now.
- Added some text when member didn't have any bots with the staff bot role.
- Remove the added reactions when confirmed or timeout.
- Edits the original message now instead of sending a new one.