### PR TITLE
Added hire command and more...

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -109,6 +109,9 @@ class Admin(commands.Cog):
     @commands.has_permissions(administrator=True)
     @commands.command()
     async def fire(self, ctx, member: discord.Member):
+        """
+        Fire someone with confirmation from Blist.
+        """
         verification_guild = self.bot.verification_guild
         main_guild = self.bot.main_guild
         staff_bot_role = main_guild.get_role(777575976124547072)
@@ -119,7 +122,7 @@ class Admin(commands.Cog):
             return await ctx.send("That is a bot or not a staff member.")
 
         if member.top_role > ctx.author.top_role:
-            return await ctx.send(f"**{ctx.author}**, I won't let you your fire someone higher than you.")
+            return await ctx.send(f"**{ctx.author}**, I won't let you fire someone higher than you.")
         if member.id == ctx.author.id:
             atc = str(self.bot.main_guild.get_member(679118121943957504))
             adu = str(self.bot.main_guild.get_member(712737377524777001)) if ctx.author.id != 712737377524777001 else atc

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -28,7 +28,9 @@ class Admin(commands.Cog):
         if staff_role not in member.roles or member.bot:
             return await ctx.send("That is a bot or not a staff member.")
         if member.id == ctx.author.id:
-            return await ctx.send(f"Please contact a fellow Admin if you want to resign from being staff at Blist. **{ctx.author}**")
+            atc = str(self.bot.main_guild.get_member(679118121943957504))
+            adu = str(self.bot.main_guild.get_member(712737377524777001)) if ctx.author.id != 712737377524777001 else atc
+            return await ctx.send(f"**{ctx.author.mention}**, i can't let you do that. Please contact {adu} if you want to resign from your staff position at Blist. ")
 
         msg = await ctx.send(f"**{ctx.author.name}**, do you really want to fire {member}? "
                              f"React with ✅ or ❌ in 30 seconds. **This action will remove __all__ staff privileges from {member}!**")

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -39,26 +39,22 @@ class Admin(commands.Cog):
             return u.id == ctx.author.id and r.message.channel.id == ctx.channel.id and \
                    str(r.emoji) in ["\U00002705", "\U0000274c"]
 
-        async def remove_reactions():
-            try:
-                await msg.clear_reactions()
-            except (discord.HTTPException, discord.Forbidden):  # ignore it.
-                # this should always work.
-                await msg.remove_reaction("\U00002705", ctx.guild.me)
-                await msg.remove_reaction("\U0000274c", ctx.guild.me)
-
         try:
             reaction, user = await self.bot.wait_for('reaction_add', check=check, timeout=30)
         except asyncio.TimeoutError:
-            await remove_reactions()
+            await msg.remove_reaction("\U00002705", ctx.guild.me)
+            await msg.remove_reaction("\U0000274c", ctx.guild.me)
             await msg.edit(content=f"~~{msg.content}~~ i guess not, cancelled.")
             return
         else:
             if str(reaction.emoji) == "\U00002705":
-                await remove_reactions()
+                await msg.remove_reaction("\U00002705", ctx.guild.me)
+                await msg.remove_reaction("\U0000274c", ctx.guild.me)
+                await msg.edit(content = f"~~{msg.content}~~ You reacted with ✅:")
                 pass
             if str(reaction.emoji) == "\U0000274c":
-                await remove_reactions()
+                await msg.remove_reaction("\U00002705", ctx.guild.me)
+                await msg.remove_reaction("\U0000274c", ctx.guild.me)
                 await msg.edit(content=f"~~{msg.content}~~ okay, cancelled.")
                 return
 
@@ -90,10 +86,7 @@ class Admin(commands.Cog):
 
         join_list = "\n".join(success_text)
         await self.bot.mod_pool.execute("DELETE FROM staff WHERE userid = $1", member.id)
-        try:
-            await msg.delete()
-        except discord.NotFound:  # maybe someone decided to the message..
-            pass
+
         await ctx.send(f"Successfully fired {member} ({member.id}).\n\n{join_list}")
 
     @commands.has_permissions(administrator = True)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -38,8 +38,7 @@ class Admin(commands.Cog):
         await msg.add_reaction("\U0000274c")
 
         def check(r, u):
-            return u.id == ctx.author.id and r.message.channel.id == ctx.channel.id and \
-                   str(r.emoji) in ["\U00002705", "\U0000274c"]
+            return u.id == ctx.author.id and r.message.channel.id == ctx.channel.id and str(r.emoji) in ["\U00002705", "\U0000274c"]
 
         try:
             reaction, user = await self.bot.wait_for('reaction_add', check=check, timeout=30)
@@ -88,7 +87,6 @@ class Admin(commands.Cog):
 
         join_list = "\n".join(success_text)
         await self.bot.mod_pool.execute("DELETE FROM staff WHERE userid = $1", member.id)
-
         await ctx.send(f"Successfully fired {member} ({member.id}).\n\n{join_list}")
 
     @commands.has_permissions(administrator = True)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -90,7 +90,6 @@ class Admin(commands.Cog):
         iso2_country = coco.convert(names=country, to='ISO2')
         if iso2_country != "not found":
 
-            member_in_db = self.bot.main_guild.get_member(406887683999137792)
             member_in_db = await self.bot.mod_pool.fetch("SELECT * FROM staff WHERE userid = $1", member.id)
             if not member_in_db:
                 success_text.append(f"❌ **Couldn't set {member}'s country flag because:** they aren't in the database.")
@@ -114,15 +113,17 @@ class Admin(commands.Cog):
         main_guild = self.bot.main_guild
         staff_bot_role = main_guild.get_role(777575976124547072)
         staff_role = self.bot.main_guild.get_role(716713561233031239)
-        user_bots = []
-        #user_bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE main_owner = $1 AND approved = True", member.id)
+        user_bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE main_owner = $1 AND approved = True", member.id)
 
         if staff_role not in member.roles or member.bot:
             return await ctx.send("That is a bot or not a staff member.")
+
+        if member.top_role > ctx.author.top_role:
+            return await ctx.send(f"**{ctx.author}**, I won't let you your fire someone higher than you.")
         if member.id == ctx.author.id:
             atc = str(self.bot.main_guild.get_member(679118121943957504))
             adu = str(self.bot.main_guild.get_member(712737377524777001)) if ctx.author.id != 712737377524777001 else atc
-            return await ctx.send(f"**{ctx.author.mention}**, i can't let you do that. Please contact {adu} if you want to resign from your staff position at Blist. ")
+            return await ctx.send(f"**{ctx.author}**, I can't let you do that. Please contact {adu} if you want to resign from your staff position at Blist. ")
 
         msg = await ctx.send(f"**{ctx.author.name}**, do you really want to fire {member}? "
                              f"React with ✅ or ❌ in 30 seconds. **This action will remove __all__ staff privileges from {member}!**")
@@ -178,7 +179,7 @@ class Admin(commands.Cog):
             success_text.append(f"❌ **{member} wasn't in the verification server...**")
 
         join_list = "\n".join(success_text)
-        #await self.bot.mod_pool.execute("DELETE FROM staff WHERE userid = $1", member.id)
+        await self.bot.mod_pool.execute("DELETE FROM staff WHERE userid = $1", member.id)
         await ctx.send(f"Successfully fired {member} ({member.id}).\n\n{join_list}")
 
     @commands.has_permissions(administrator = True)

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -185,50 +185,59 @@ New Message
             role = member.guild.get_role(716684129453735936)
             await member.add_roles(role)
 
-        if member.guild == self.bot.verification_guild and member.bot:
-            bot_role = self.bot.verification_guild.get_role(763187834219003934)
-            await member.add_roles(bot_role)
-            overwrites = {
-                member.guild.get_role(763177553636098082): discord.PermissionOverwrite(manage_channels=True),
-                member.guild.get_role(763187834219003934): discord.PermissionOverwrite(read_messages=False),
-                member: discord.PermissionOverwrite(read_messages=True),
-            }
-            category = await member.guild.create_category(name=member.name, overwrites=overwrites)
-            channel = await category.create_text_channel(name="Testing")
-            await category.create_text_channel(name="Testing-NSFW", nsfw=True)
-            await category.create_voice_channel(name="Voice Testing", bitrate=member.guild.bitrate_limit)
+        if member.guild.id == self.bot.verification_guild.id:
+            if member.bot:
+                bot_role = self.bot.verification_guild.get_role(763187834219003934)
+                await member.add_roles(bot_role)
+                overwrites = {
+                    member.guild.get_role(763177553636098082): discord.PermissionOverwrite(manage_channels=True),
+                    member.guild.get_role(763187834219003934): discord.PermissionOverwrite(read_messages=False),
+                    member: discord.PermissionOverwrite(read_messages=True),
+                }
+                category = await member.guild.create_category(name=member.name, overwrites=overwrites)
+                channel = await category.create_text_channel(name="Testing")
+                await category.create_text_channel(name="Testing-NSFW", nsfw=True)
+                await category.create_voice_channel(name="Voice Testing", bitrate=member.guild.bitrate_limit)
 
-            bot = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE id = $1", member.id)
+                bot = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE id = $1", member.id)
 
-            embed = discord.Embed(
-                title=str(member),
-                color=discord.Color.blurple(),
-                description=wrap(
-                    f"""
-                    >>> Owner: ``{str(self.bot.main_guild.get_member(bot[0]['main_owner']))}``
-                    Prefix: ``{bot[0]['prefix']}``
-                    Tags: ``{', '.join(list(bot[0]['tags']))}``
-                    Added: ``{bot[0]['joined'].strftime('%D')}``
-                    """
+                embed = discord.Embed(
+                    title=str(member),
+                    color=discord.Color.blurple(),
+                    description=wrap(
+                        f"""
+                        >>> Owner: ``{str(self.bot.main_guild.get_member(bot[0]['main_owner']))}``
+                        Prefix: ``{bot[0]['prefix']}``
+                        Tags: ``{', '.join(list(bot[0]['tags']))}``
+                        Added: ``{bot[0]['joined'].strftime('%D')}``
+                        """
+                    )
                 )
-            )
-            embed.add_field(
-                name="**Links**",
-                value=wrap(
-                    f"""
-                    >>> Privacy Policy: {bot[0]['privacy_policy_url'] or 'None'}
-                    Website: {bot[0]['website'] or 'None'}
-                    Invite: {bot[0]['invite_url'] or 'Default'}
-                    Blist Link: https://blist.xyz/bot/{member.id}/
-                    """
+                embed.add_field(
+                    name="**Links**",
+                    value=wrap(
+                        f"""
+                        >>> Privacy Policy: {bot[0]['privacy_policy_url'] or 'None'}
+                        Website: {bot[0]['website'] or 'None'}
+                        Invite: {bot[0]['invite_url'] or 'Default'}
+                        Blist Link: https://blist.xyz/bot/{member.id}/
+                        """
+                    )
                 )
-            )
-            embed.add_field(name="Short Description",
-                            value=bot[0]['short_description'], inline=False)
-            embed.add_field(name="Notes", value=bot[0]['notes'], inline=False)
-            embed.set_thumbnail(url=member.avatar_url)
-            message = await channel.send(embed=embed)
-            await message.pin()
+                embed.add_field(name="Short Description",
+                                value=bot[0]['short_description'], inline=False)
+                if bot[0]['notes']:
+                    embed.add_field(name="Notes", value=bot[0]['notes'], inline=False)
+                embed.set_thumbnail(url=member.avatar_url)
+                message = await channel.send(embed=embed)
+                await message.pin()
+
+            if not member.bot:
+                query = await self.bot.mod_pool.fetch("SELECT rank FROM staff WHERE userid = $1", member.id)
+                rank = query[0]['rank']
+                role = discord.utils.get(self.bot.verification_guild.roles, name = str(rank))
+                staff_role = self.bot.verification_guild.get_role(763177553636098082)
+                await member.add_roles(staff_role, role)
 
     @commands.Cog.listener()
     async def on_member_update(self, before, after):
@@ -287,7 +296,7 @@ New Message
                        #716713498360545352, 716713293330514041]
         set_difference1 = set(before.roles) - set(after.roles)
         set_difference2 = set(after.roles) - set(before.roles)
-        if list(set_difference2) != []:
+        if list(set_difference2):
             new_roles = list(set_difference2)
             if new_roles[0].id not in self.bot.staff_roles:
                 return
@@ -329,10 +338,12 @@ New Message
                         if user["denied"]:
                             await self.bot.pool.execute("DELETE FROM main_site_bot WHERE id = $1", user["id"])
                             return
+                        bot = self.bot.main_guild.get_member(user['id'])
+                        is_in_server = "(not in this server)" if not bot else ""
                         bots = " \n".join(
-                            [f"{user['name']} (<@{user['id']}>)"])
-                        listed_bots = f"{len(x)} bot listed:" if len(
-                            x) == 1 else f"{len(x)} bots listed:"
+                            [f"{user['name']} (<@{user['id']}>) ({is_in_server})"])
+                        bot_or_bots = "bot" if len(x) == 1 else "bots"
+                        listed_bots = f"{len(x)} {bot_or_bots} listed:"
                         embed = discord.Embed(
                             description=f"{member} ({member.id}) left the server and has {listed_bots}\n\n{bots} \n\nUse the `b!delete` command to delete the bot",
                             color=discord.Color.red())

--- a/cogs/staff_site.py
+++ b/cogs/staff_site.py
@@ -29,7 +29,7 @@ class Staff(commands.Cog):
 
         embed = discord.Embed(
             title="Queue",
-            url="https://blist.xyz/staff/queue/",
+            url="https://blist.xyz/staff#verification",
             description='\n'.join(listed_bots) if listed_bots else "All Clear",
             color=discord.Color.blurple()
         )


### PR DESCRIPTION
- Added hire command, see the docstring.
- Improved fire command a bit:
-- Prevent a admin from firing themself, this will send a (nice) message 
-- Added some text when member didn't have any bots with the staff bot role.
-- Remove the added reactions when confirmed or timeout.
-- Edits the original message now instead of sending a new one.
- Fixed botinfo not sending in the verification server.
- Added part in on_member_join to add the mod role to joining humans in the verification server.
- Improved the dm command by adding arguments and flags, see the docstring/code.
- Fixed hyperlink on title for queue command.