### PR TITLE
Use ISO 8601 for representing dates

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -279,7 +279,7 @@ New Message
                         >>> Owner: ``{str(self.bot.main_guild.get_member(bot[0]['main_owner']))}``
                         Prefix: ``{bot[0]['prefix']}``
                         Tags: ``{', '.join(list(bot[0]['tags']))}``
-                        Added: ``{bot[0]['joined'].strftime('%D')}``
+                        Added: ``{bot[0]['joined'].strftime('%F')}``
                         """
                     )
                 )

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -523,7 +523,7 @@ class General(commands.Cog):
                 All-Time Votes: ``{b['total_votes']}``
                 Certified: ``{b['certified']}``
                 Server Count: ``{b['server_count']}``
-                Added: ``{b['joined'].strftime('%D')}``
+                Added: ``{b['joined'].strftime('%F')}``
                 """
             ),
             color=discord.Color.blurple()

--- a/cogs/staff_site.py
+++ b/cogs/staff_site.py
@@ -241,7 +241,7 @@ class Staff(commands.Cog):
             color=discord.Color.blurple(),
             description=wrap(
                 f"""
-                >>> Staff Since: ``{query['joinedat'].strftime("%D")}``
+                >>> Staff Since: ``{query['joinedat'].strftime("%F")}``
                 Bots Approved: ``{query['approved']}``
                 Bots Denied: ``{query['denied']}``
                 Country: ``{query['country_code'] or 'Not Specified'}``


### PR DESCRIPTION
This changes the representation of dates to use an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Dates) and [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) compliant format.

## Why change this?
The use of American style dates is ambiguous. For example, the date `06/02/2021` can be interpreted in two different ways around the world. Europeans would say this date would be February 6, 2021. Americans would say this date would be June 2, 2021. As you can see, this representation of dates should not be used.

The purpose of ISO 8601 is to solve the aforementioned issues. As Blist is intended for a worldwide audience, these changes must be seriously considered. ISO 8601 defines an unambiguous format meant to be used worldwide, while RFC 3339 standardizes ISO 8601 for use on the Internet.