### PR TITLE
Many improvements, mainly to the reviewing experience.

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -24,7 +24,6 @@ class Events(commands.Cog):
         self.check_join.start()  # pylint: disable=no-member
         self.change_status.start()
         self.update_statuses.start()
-        self.check_bot_testing.start()
 
     def cog_unload(self):
         self.bot.on_error = self.old_on_error
@@ -282,38 +281,36 @@ New Message
                     pass
 
                 bot = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE id = $1", member.id)
-                if not bot:
-                    pass
-                else:
-                    embed = discord.Embed(
-                        title = str(member),
-                        color = discord.Color.blurple(),
-                        description = wrap(
-                            f"""
-                            >>> Owner: ``{str(self.bot.main_guild.get_member(bot[0]['main_owner']))}``
-                            Prefix: ``{bot[0]['prefix']}``
-                            Tags: ``{', '.join(list(bot[0]['tags']))}``
-                            Added: ``{bot[0]['added'].strftime('%F')}``
-                            """
-                        )
+
+                embed = discord.Embed(
+                    title = str(member),
+                    color = discord.Color.blurple(),
+                    description = wrap(
+                        f"""
+                        >>> Owner: ``{str(self.bot.main_guild.get_member(bot[0]['main_owner']))}``
+                        Prefix: ``{bot[0]['prefix']}``
+                        Tags: ``{', '.join(list(bot[0]['tags']))}``
+                        Added: ``{bot[0]['added'].strftime('%F')}``
+                        """
                     )
-                    embed.add_field(
-                        name = "**Links**",
-                        value = wrap(
-                            f"""
-                            >>> Privacy Policy: {bot[0]['privacy_policy_url'] or 'None'}
-                            Website: {bot[0]['website'] or 'None'}
-                            Invite: {bot[0]['invite_url'] or 'Default'}
-                            Blist Link: https://blist.xyz/bot/{member.id}/
-                            """
-                        )
+                )
+                embed.add_field(
+                    name = "**Links**",
+                    value = wrap(
+                        f"""
+                        >>> Privacy Policy: {bot[0]['privacy_policy_url'] or 'None'}
+                        Website: {bot[0]['website'] or 'None'}
+                        Invite: {bot[0]['invite_url'] or 'Default'}
+                        Blist Link: https://blist.xyz/bot/{member.id}/
+                        """
                     )
-                    embed.add_field(name = "Short Description",
-                                    value = bot[0]['short_description'], inline = False)
-                    embed.add_field(name = "Notes", value = bot[0]['notes'] or 'None', inline = False)
-                    embed.set_thumbnail(url = member.avatar_url)
-                    message = await channel.send(embed = embed)
-                    await message.pin()
+                )
+                embed.add_field(name = "Short Description",
+                                value = bot[0]['short_description'], inline = False)
+                embed.add_field(name = "Notes", value = bot[0]['notes'] or 'None', inline = False)
+                embed.set_thumbnail(url = member.avatar_url)
+                message = await channel.send(embed = embed)
+                await message.pin()
 
             if not member.bot:
                 rank_user = self.bot.main_guild.get_member(member.id)
@@ -446,10 +443,7 @@ New Message
                     file = discord.File(file_name, file.name))
 
                 await category.delete()
-                try:
-                    del self.test_categories[member.id]
-                except KeyError:
-                    pass
+                del self.test_categories[member.id]
                 if os.path.exists(file_name):
                     try:
                         os.remove(file_name)
@@ -495,17 +489,6 @@ New Message
                                                  "being tested here has left the main server, deny it!")
                                 except:
                                     pass
-
-    @commands.Cog.listener("on_ready")
-    async def if_bot_restarted(self):
-        await self.bot.wait_until_ready()
-        test_categories = [x for x in self.bot.verification_guild.categories
-                           if x.id not in [763183878457262083, 734527161289015338]]
-        if test_categories:
-            for cat in test_categories:
-                testing_bot = discord.utils.get(self.bot.verification_guild.members, name = cat.name)
-                if testing_bot:
-                    self.test_categories[testing_bot.id] = cat.id
 
     @tasks.loop(minutes = 30)
     async def check_join(self):
@@ -553,40 +536,6 @@ New Message
         ]
         await self.bot.change_presence(activity = discord.Game(name = random.choice(options)))
 
-    # i agree, @A Trash Coder .
-    @tasks.loop(minutes = 60)
-    async def check_bot_testing(self):
-        queued_bots = await self.bot.pool.fetch("SELECT added, id FROM main_site_bot WHERE approved = False AND denied = False")
-        if not queued_bots:
-            return
-
-        for x in queued_bots:
-            bot_id = x['id']
-            if bot_id in self.test_categories.keys():
-                testing_category = self.bot.verification_guild.get_channel(self.test_categories[bot_id])
-                if not testing_category:
-                    return
-
-                bot_member = self.bot.verification_guild.get_member(bot_id)
-                category_created_at = testing_category.created_at.replace(tzinfo = datetime.timezone.utc)
-                testing_hours = time_took(dt = category_created_at, only_hours = True,
-                                          now_dt = datetime.datetime.utcnow().replace(tzinfo = datetime.timezone.utc))
-
-                if int(testing_hours) >= 2:
-                    ovm = [x for x in testing_category.overwrites if isinstance(x, discord.Member) and not x.bot]
-                    if ovm:  # user overwrites, hold command is used.
-                        return
-                    else:
-                        for channel in testing_category.text_channels:
-                            try:
-                                await channel.send(
-                                    f"Friendly reminder that {bot_member.mention} has been waiting for more than "
-                                    f"{testing_hours} hours without the category being on hold via the `b!hold` "
-                                    "command. Please use that command if you are waiting for a response or any other "
-                                    "reason"
-                                )
-                            except:
-                                pass
 
 def setup(bot):
     bot.add_cog(Events(bot))

--- a/cogs/staff_site.py
+++ b/cogs/staff_site.py
@@ -191,7 +191,7 @@ class Staff(commands.Cog):
         em = discord.Embed(
             description=f"``{bot}`` by ``{self.bot.main_guild.get_member(bots)}`` was denied by ``{ctx.author}`` for: \n```{reason}```",
             color=discord.Color.red())
-        await self.bot.get_channel(826076038765215827).send(embed=em)
+        await self.bot.get_channel(716446098859884625).send(embed=em)
         try:
             await bot.kick(reason="Bot Denied")
         except Exception:

--- a/cogs/staff_site.py
+++ b/cogs/staff_site.py
@@ -1,5 +1,6 @@
+import datetime
 from textwrap import dedent as wrap
-from typing import Union
+from typing import Union, Tuple, Dict
 
 import discord
 import googletrans
@@ -7,6 +8,36 @@ import asyncio
 import typing
 from discord.ext import commands, flags
 from utils import checks
+from utils.time import time_took
+
+
+def bot_log_embed(ctx, bot_and_owner: Tuple[Union[discord.Member, int], Union[discord.Member, int]], *,
+                  reason: str = None):
+    def escape_markdown(txt: str):
+        return discord.utils.escape_markdown(str(txt))
+    bot, bot_owner = bot_and_owner
+    bot_text = f"{escape_markdown(str(bot))} ({bot.id})" \
+        if isinstance(bot, discord.Member) else escape_markdown(str(bot))
+    bot_owner_text = f"{escape_markdown(str(bot_owner))} ({bot_owner.id})" \
+        if isinstance(bot_owner, discord.Member) else escape_markdown(str(bot_owner))
+
+    command_author = f"{escape_markdown(ctx.author)} | ({ctx.author.id})"
+    embed_stuff_dict = {
+        "deny": ("Bot denied", discord.Color.red(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
+                 f"**Reviewer:** {command_author}", str(reason)),
+        "delete": ("Bot deleted", discord.Color.red(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
+                   f"**Author:** {command_author}", str(reason)),
+        "approve": ("Bot approved", discord.Color.green(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
+                    f"**Reviewer:** {command_author}", None)
+    }
+    title, color, description, command_invoker, reason = embed_stuff_dict.get(str(ctx.command.name))
+    reason = f"**Reason:** {reason}" if reason is not None else ''
+    emb = discord.Embed(
+        title = title,
+        description = f"{description}\n\n{command_invoker}\n{reason}",
+        colour = color
+    )
+    return emb
 
 
 class Staff(commands.Cog):
@@ -14,8 +45,8 @@ class Staff(commands.Cog):
         self.bot = bot
         self.translator = googletrans.Translator()
 
-    @commands.has_permissions(kick_members=True)
-    @commands.group(invoke_without_command=True, aliases=["q"])
+    @commands.has_permissions(kick_members = True)
+    @commands.group(invoke_without_command = True, aliases = ["q"])
     async def queue(self, ctx):
         bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE approved = False AND denied = False")
         if not bots:
@@ -27,24 +58,41 @@ class Staff(commands.Cog):
         for x in bots:
             if x['id'] in test_categories.keys():
                 testing_category = self.bot.verification_guild.get_channel(test_categories[x['id']])
+                if not testing_category:
+                    pass
                 testing_channel = discord.utils.get(testing_category.text_channels, name = "testing")
+                category_created_at = testing_category.created_at.replace(tzinfo = datetime.timezone.utc)
+                too_long = time_took(dt = category_created_at, only_hours = True,
+                                     now_dt = datetime.datetime.utcnow().replace(tzinfo = datetime.timezone.utc))
+                if int(too_long) >= 6:
+                    too_long = f"|| {int(too_long)}+ hours in testing ⚠️"
+                else:
+                    too_long = ""
+
                 being_tested = f"(being tested in {testing_category.name} | {testing_channel.mention})"
-                listed_bots.append(f"~~{x['username']}~~ {being_tested}")
+                listed_bots.append(f"~~{x['username']}~~ {being_tested} {too_long}")
             else:
+                too_long = time_took(dt = x['added'], only_hours = True,
+                                     now_dt = datetime.datetime.utcnow().replace(tzinfo = datetime.timezone.utc))
+                if int(too_long) >= 2:
+                    too_long = f"|| {int(too_long)}+ hours in queue ⚠️"
+                else:
+                    too_long = ""
                 invite = str(
-                    discord.utils.oauth_url(x['id'], guild=self.bot.verification_guild)) + "&disable_guild_select=true"
-                listed_bots.append(f"{x['username']} [Invite]({invite})")
+                    discord.utils.oauth_url(x['id'],
+                                            guild = self.bot.verification_guild)) + "&disable_guild_select=true"
+                listed_bots.append(f"{x['username']} [Invite]({invite}) {too_long}")
 
         embed = discord.Embed(
-            title="Queue",
-            url="https://blist.xyz/staff#verification",
-            description='\n'.join(listed_bots) if listed_bots else "All Clear",
-            color=discord.Color.blurple()
+            title = "Queue",
+            url = "https://blist.xyz/staff#verification",
+            description = '\n'.join(listed_bots) if listed_bots else "All Clear",
+            color = discord.Color.blurple()
         )
-        await ctx.send(embed=embed)
+        await ctx.send(embed = embed)
 
     @checks.main_guild_only()
-    @queue.command(aliases=["c"])
+    @queue.command(aliases = ["c"])
     async def certification(self, ctx):
         bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE awaiting_certification = True")
         if bots is None:
@@ -56,22 +104,23 @@ class Staff(commands.Cog):
             listed_bots.append(f"{x['username']} | Added: {x['added']}")
 
         embed = discord.Embed(
-            title="Certification Queue",
-            description='\n'.join(listed_bots) if listed_bots else "All Clear",
-            color=discord.Color.blurple()
+            title = "Certification Queue",
+            description = '\n'.join(listed_bots) if listed_bots else "All Clear",
+            color = discord.Color.blurple()
         )
-        await ctx.send(embed=embed)
+        await ctx.send(embed = embed)
 
     @checks.verification_guild_only()
-    @commands.has_permissions(kick_members=True)
-    @commands.command()
+    @commands.has_permissions(kick_members = True)
+    @commands.command(aliases = ['accept'])
     async def approve(self, ctx, *, bot: discord.Member):
         if not bot.bot:
             await ctx.send("This is not a bot.")
             return
 
         bots = await self.bot.pool.fetchrow(
-            "SELECT main_owner, referred_by FROM main_site_bot WHERE approved = False AND denied = False AND id = $1", bot.id)
+            "SELECT main_owner, referred_by FROM main_site_bot WHERE approved = False AND denied = False AND id = $1",
+            bot.id)
         if not bots:
             await ctx.send("This bot is not awaiting approval")
             return
@@ -82,9 +131,11 @@ class Staff(commands.Cog):
             return
 
         if bots["referred_by"] != "":
-            user_id = await self.bot.pool.fetchval("SELECT id FROM main_site_user WHERE referrer_code  = $1", bots["referred_by"])
+            user_id = await self.bot.pool.fetchval("SELECT id FROM main_site_user WHERE referrer_code  = $1",
+                                                   bots["referred_by"])
             if user_id:
-                await self.bot.pool.execute("UPDATE main_site_user SET referrals = referrals + 1 WHERE id = $1", user_id)
+                await self.bot.pool.execute("UPDATE main_site_user SET referrals = referrals + 1 WHERE id = $1",
+                                            user_id)
 
         await self.bot.pool.execute("UPDATE main_site_user SET developer = True WHERE id = $1", bots["main_owner"])
         await self.bot.pool.execute("UPDATE main_site_bot SET approved = True WHERE id = $1", bot.id)
@@ -93,17 +144,17 @@ class Staff(commands.Cog):
         queued_bots = await self.bot.pool.fetchval(
             "SELECT COUNT(*) FROM main_site_bot WHERE approved = False AND denied = False")
         invite = str(discord.utils.oauth_url(
-            bot.id, guild=self.bot.main_guild)) + "&disable_guild_select=true"
+            bot.id, guild = self.bot.main_guild)) + "&disable_guild_select=true"
         embed = discord.Embed(
-            title=f"Approved {bot.name}",
-            description=f"[Invite!]({invite})\n\nThere are {queued_bots} bot(s) in the queue.",
-            color=discord.Color.blurple()
+            title = f"Approved {bot.name}",
+            description = f"[Invite!]({invite})\n\nThere are {queued_bots} bot(s) in the queue.",
+            color = discord.Color.blurple()
         )
-        await self.bot.verification_guild.get_channel(763183376311517215).send(content=ctx.author.mention, embed=embed)
-        em = discord.Embed(
-            description=f"``{bot}`` by ``{self.bot.main_guild.get_member(bots['main_owner'])}`` was approved by ``{ctx.author}``",
-            color=discord.Color.blurple())
-        await self.bot.get_channel(716446098859884625).send(embed=em)
+        await self.bot.verification_guild.get_channel(763183376311517215).send(
+            content = ctx.author.mention, embed = embed)
+
+        em = bot_log_embed(ctx, (bot, owner))
+        await self.bot.get_channel(716446098859884625).send(embed = em)
 
         dev_role = self.bot.main_guild.get_role(716684805286133840)
 
@@ -119,9 +170,9 @@ class Staff(commands.Cog):
 
         await bot.kick()
         bots = await self.bot.pool.fetchval("SELECT COUNT(*) FROM main_site_bot")
-        await self.bot.change_presence(activity=discord.Game(name=f"Watching {bots} bots"))
+        await self.bot.change_presence(activity = discord.Game(name = f"Watching {bots} bots"))
 
-    @commands.has_permissions(kick_members=True)
+    @commands.has_permissions(kick_members = True)
     @commands.command()
     async def deny(self, ctx, bot: Union[discord.Member, discord.User]):
         if not bot.bot:
@@ -156,25 +207,28 @@ class Staff(commands.Cog):
             "The bot owner did not respond or complete fixes within the time frame given."
         ]
 
-        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start=1)])
+        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start = 1)])
         embed = discord.Embed(
-            title=f"Denying {bot.name}",
-            description=join_preset_reasons,
-            color=discord.Color.red()
+            title = f"Denying {bot.name}",
+            description = join_preset_reasons,
+            color = discord.Color.red()
         )
-        embed.set_footer(text="You have 20 seconds to provide a valid reason number or type your own reason.")
-        await ctx.send(embed=embed)
+        embed.set_footer(text = "You have 20 seconds to provide a valid reason number or type your own reason.")
+        await ctx.send(embed = embed)
 
         try:
-            msg = await self.bot.wait_for("message", timeout=20.0, check=wait_for_check)
+            msg = await self.bot.wait_for("message", timeout = 20.0, check = wait_for_check)
         except asyncio.TimeoutError:
-            return await ctx.send("You did not provide a reason number or custom reason in time. The command was cancelled.")
+            return await ctx.send(
+                "You did not provide a reason number or custom reason in time. The command was cancelled.")
         else:
-            if not msg.content.isdigit():
-                reason = msg.content # custom reason
-
             if msg.content.isdigit():
-                reason = preset_reasons[int(msg.content)-1]
+                try:
+                    reason = preset_reasons[int(msg.content) - 1]
+                except KeyError:
+                    return await ctx.send(f"{msg.content} is not valid reason number. The command was cancelled.")
+            else:
+                reason = msg.content  # custom reason
 
         await self.bot.mod_pool.execute("UPDATE staff SET denied = denied + 1 WHERE userid = $1", ctx.author.id)
 
@@ -186,20 +240,21 @@ class Staff(commands.Cog):
 
         await self.bot.pool.execute("UPDATE main_site_bot SET denied = True WHERE id = $1", bot.id)
         embed = discord.Embed(
-            description=f"Denied {bot.name}", color=discord.Color.red())
-        await ctx.send(embed=embed)
-        em = discord.Embed(
-            description=f"``{bot}`` by ``{self.bot.main_guild.get_member(bots)}`` was denied by ``{ctx.author}`` for: \n```{reason}```",
-            color=discord.Color.red())
-        await self.bot.get_channel(716446098859884625).send(embed=em)
+            description = f"Denied {bot.name}", color = discord.Color.red())
+        await ctx.send(embed = embed)
+
+        bot_owner = self.bot.main_guild.get_member(bots)
+        bot_owner = bot_owner if bot_owner else int(bots)
+        em = bot_log_embed(ctx, (bot, bot_owner), reason = str(reason))
+        await self.bot.get_channel(716446098859884625).send(embed = em)
+
         try:
-            await bot.kick(reason="Bot Denied")
+            await bot.kick(reason = "Bot Denied")
         except Exception:
             await ctx.send("Couldn't kick bot")
 
-
     @checks.main_guild_only()
-    @commands.has_permissions(kick_members=True)
+    @commands.has_permissions(kick_members = True)
     @commands.command()
     async def delete(self, ctx, bot: Union[discord.Member, int]):
         bot_user = None
@@ -213,12 +268,13 @@ class Staff(commands.Cog):
             return
 
         bots = await self.bot.pool.fetchrow(
-            "SELECT main_owner, username, certified, discriminator FROM main_site_bot WHERE approved = True AND id = $1", bot_user.id if bot_user else bot)
+            "SELECT main_owner, username, certified, discriminator FROM main_site_bot WHERE approved = True AND id = $1",
+            bot_user.id if bot_user else bot)
         if not bots:
             await ctx.send("This bot is not on the list")
             return
 
-        def wait_for_check2(m):
+        def wait_for_check(m):
             return m.channel.id == ctx.channel.id and m.author.id == ctx.author.id
 
         preset_reasons = [
@@ -232,71 +288,73 @@ class Staff(commands.Cog):
             "Bot sent unwanted spam",
         ]
 
-        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start=1)])
+        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start = 1)])
         embed = discord.Embed(
-            title=f"Deleting {bot.name}",
-            description=join_preset_reasons,
-            color=discord.Color.red()
+            title = f"Deleting {bot.name}",
+            description = join_preset_reasons,
+            color = discord.Color.red()
         )
-        embed.set_footer(text="You have 20 seconds to provide a valid reason number or type your own reason.")
-        await ctx.send(embed=embed)
+        embed.set_footer(text = "You have 20 seconds to provide a valid reason number or type your own reason.")
+        await ctx.send(embed = embed)
 
         try:
-            message = await self.bot.wait_for("message", timeout=20.0, check=wait_for_check2)
+            message = await self.bot.wait_for("message", timeout = 20.0, check = wait_for_check)
         except asyncio.TimeoutError:
-            return await ctx.send("You did not provide a reason number or custom reason in time. The command was cancelled.")
+            return await ctx.send(
+                "You did not provide a reason number or custom reason in time. The command was cancelled.")
         else:
-            if not message.content.isdigit():
-                reason = message.content # custom reason
-
             if message.content.isdigit():
-                reason = preset_reasons[int(message.content)-1]
+                try:
+                    reason = preset_reasons[int(message.content) - 1]
+                except KeyError:
+                    return await ctx.send(f"{message.content} is not valid reason number. The command was cancelled.")
+            else:
+                reason = message.content  # custom reason
 
-
-
-
-        bot_db = await self.bot.pool.fetchval("SELECT unique_id FROM main_site_bot WHERE id = $1", bot_user.id if bot_user else bot)
+        bot_db = await self.bot.pool.fetchval("SELECT unique_id FROM main_site_bot WHERE id = $1",
+                                              bot_user.id if bot_user else bot)
         await self.bot.pool.execute("DELETE FROM main_site_vote WHERE bot_id = $1", bot_db)
         await self.bot.pool.execute("DELETE FROM main_site_review WHERE bot_id = $1", bot_db)
         await self.bot.pool.execute("DELETE FROM main_site_auditlogaction WHERE bot_id = $1", bot_db)
         await self.bot.pool.execute("DELETE FROM main_site_bot WHERE id = $1", bot_user.id if bot_user else bot)
 
         embed = discord.Embed(
-            description=f"Deleted {bots['username']}", color=discord.Color.red())
-        await ctx.send(embed=embed)
+            description = f"Deleted {bots['username']}", color = discord.Color.red())
+        await ctx.send(embed = embed)
 
-        em = discord.Embed(
-            description=f"``{bots['username']}#{bots['discriminator']}`` by ``{ctx.guild.get_member(bots['main_owner']) or bots['main_owner']}`` was deleted by ``{ctx.author}`` for: \n```{reason}```",
-            color=discord.Color.red())
-        await self.bot.get_channel(716446098859884625).send(embed=em)
+        bot_owner = self.bot.main_guild.get_member(bots['main_owner'])
+        bot_owner = bot_owner if bot_owner else int(bots['main_owner'])
+        bot_member = self.bot.main_guild.get_member(bots['id']) or self.bot.verification_guild.get_member(bots['id'])
+        bot_member = bot_member if bot_member else f"{bots['username']}#{bots['discriminator']} ({bots['id']})"
+        em = bot_log_embed(ctx, (bot_member, bot_owner), reason = str(reason))
+        await self.bot.get_channel(716446098859884625).send(embed = em)
 
-        member = ctx.guild.get_member(bots['main_owner'])
-        if member and bots['certified'] is True:
+        if bot_owner and bots['certified'] is True:
             certified_dev_role = ctx.guild.get_role(716724317207003206)
-            await member.remove_roles(certified_dev_role)
+            await bot_owner.remove_roles(certified_dev_role)
 
         has_other_bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE main_owner = $1",
                                                    bots['main_owner'])
-        if not has_other_bots and member:
+        if not has_other_bots and bot_owner:
             dev_role = ctx.guild.get_role(716684805286133840)
-            await member.remove_roles(dev_role)
+            await bot_owner.remove_roles(dev_role)
             await self.bot.pool.execute("UPDATE main_site_user SET developer = False WHERE id = $1",
                                         bots['main_owner'])
 
         if bot_user is not None:
-            await bot_user.kick(reason="Bot Deleted")
+            await bot_user.kick(reason = "Bot Deleted")
 
-    @commands.has_permissions(kick_members=True)
+    @commands.has_permissions(kick_members = True)
     @commands.command()
     async def say(self, ctx, *, msg: commands.clean_content):
         """Make blist repeat what you said"""
         await ctx.send(msg)
 
-    @flags.add_flag("--to", type=str, default="en")
-    @flags.add_flag("--from", type=str, default="auto")
-    @flags.add_flag("message", nargs="+")
-    @commands.has_permissions(kick_members=True)
-    @commands.command(hidden=True, aliases=["t"], cls=flags.FlagCommand)
+    @flags.add_flag("--to", type = str, default = "en")
+    @flags.add_flag("--from", type = str, default = "auto")
+    @flags.add_flag("message", nargs = "+")
+    @commands.has_permissions(kick_members = True)
+    @commands.command(hidden = True, aliases = ["t"], cls = flags.FlagCommand)
     async def translate(self, ctx, **arguments):
         """
         Translates a message to English (default) using Google translate.
@@ -308,20 +366,20 @@ class Staff(commands.Cog):
         message = ' '.join(arguments['message'])
         try:
             translated = self.translator.translate(
-                message, dest=arguments['to'], src=arguments['from'])
+                message, dest = arguments['to'], src = arguments['from'])
         except ValueError:
             return await ctx.send(
-                embed=discord.Embed(description="That is not a valid language!", color=discord.Color.red()))
+                embed = discord.Embed(description = "That is not a valid language!", color = discord.Color.red()))
 
         src = googletrans.LANGUAGES.get(
             translated.src, '(auto-detected)').title()
         dest = googletrans.LANGUAGES.get(translated.dest, 'Unknown').title()
-        embed = discord.Embed(color=discord.Color.blurple())
-        embed.add_field(name=f"{src} ({translated.src})",
-                        value=translated.origin, inline=False)
-        embed.add_field(name=f"{dest} ({translated.dest})",
-                        value=translated.text, inline=False)
-        await ctx.send(embed=embed)
+        embed = discord.Embed(color = discord.Color.blurple())
+        embed.add_field(name = f"{src} ({translated.src})",
+                        value = translated.origin, inline = False)
+        embed.add_field(name = f"{dest} ({translated.dest})",
+                        value = translated.text, inline = False)
+        await ctx.send(embed = embed)
 
     @commands.command()
     async def staff(self, ctx, member: discord.Member = None):
@@ -333,8 +391,8 @@ class Staff(commands.Cog):
             return await ctx.send("This user is not staff!")
         query = query[0]
         embed = discord.Embed(
-            color=discord.Color.blurple(),
-            description=wrap(
+            color = discord.Color.blurple(),
+            description = wrap(
                 f"""
                 >>> Staff Since: ``{query['joinedat'].strftime("%F")}``
                 Bots Approved: ``{query['approved']}``
@@ -345,12 +403,12 @@ class Staff(commands.Cog):
                 """
             )
         )
-        embed.set_author(name=member, icon_url=str(member.avatar_url))
-        await ctx.send(embed=embed)
+        embed.set_author(name = member, icon_url = str(member.avatar_url))
+        await ctx.send(embed = embed)
 
     @commands.has_permissions(kick_members = True)
     @checks.verification_guild_only()
-    @commands.command()
+    @commands.command(aliases = ['lock'])
     async def hold(self, ctx, message: typing.Optional[discord.Message] = None, *, reason: str):
         """ Waiting on a bot owner to fix their bot? Use this!
         You can also include the message url of the message to the owner like so, `b!hold URLHERE reason here`
@@ -361,42 +419,55 @@ class Staff(commands.Cog):
             colour = discord.Color.blurple(),
             timestamp = ctx.message.created_at
         )
-        em.set_author(name=ctx.author.name, icon_url=ctx.author.avatar_url)
+        em.set_author(name = ctx.author.name, icon_url = ctx.author.avatar_url)
         if message:
             em.description = f"[message link]({message.jump_url})"
 
-        others = discord.PermissionOverwrite(send_messages = False)
-        author = discord.PermissionOverwrite(send_messages = True)
-        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = others,
+        staff_role = ctx.channel.category.overwrites_for(ctx.guild.get_role(763177553636098082))
+        staff_role.send_messages = False
+        everyone = ctx.channel.category.overwrites_for(ctx.guild.default_role)
+        everyone.send_messages = False
+        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = staff_role,
                                                    reason = f"hold review for {reason}")
-        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = others,
+        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = everyone,
                                                    reason = f"hold review for {reason}")
-        await ctx.channel.category.set_permissions(ctx.author, overwrite = author,
-                                                   reason = f"hold review for {reason}")
+        await ctx.channel.category.set_permissions(ctx.author, reason = f"hold review for {reason}",
+                                                   send_messages = True)
 
-        msg = await ctx.send(embed=em)
+        msg = await ctx.send(embed = em)
         await ctx.message.delete()
         await msg.pin()
 
     @commands.has_permissions(kick_members = True)
     @checks.verification_guild_only()
-    @commands.command()
-    async def unlock(self, ctx):
-        """Unlock the channel to start reviewing a bot again."""
+    @commands.command(aliases = ['unlock'])
+    async def unhold(self, ctx):
+        """Unhold the channel to start reviewing a bot again."""
         em = discord.Embed(
             title = "Unlocked the channel, you can continue.",
             colour = discord.Color.blurple()
         )
         em.set_author(name = ctx.author.name, icon_url = ctx.author.avatar_url)
 
-        others = discord.PermissionOverwrite(send_messages = True)
-        author = discord.PermissionOverwrite(send_messages = None)
-        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = others, reason = "unlocked")
-        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = others, reason = "unlocked")
-        await ctx.channel.category.set_permissions(ctx.author, overwrite = author, reason = "unlocked")
+        staff_role = ctx.channel.category.overwrites_for(ctx.guild.get_role(763177553636098082))
+        staff_role.send_messages = None
+        everyone = ctx.channel.category.overwrites_for(ctx.guild.default_role)
+        everyone.send_messages = None
+        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = staff_role,
+                                                   reason = "unlocked")
+        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = everyone, reason = "unlocked")
+        await ctx.channel.category.set_permissions(ctx.author, overwrite = None, reason = "unlocked")
 
-        await ctx.send(embed=em)
+        await ctx.send(embed = em)
         await ctx.message.delete()
+        channel_pins_hold_embeds = [x for x in await ctx.channel.pins() if x.embeds and x.embeds[0].author]
+        if not channel_pins_hold_embeds:
+            return
+
+        try:
+            await channel_pins_hold_embeds[0].unpin()
+        except:
+            return
 
 
 def setup(bot):

--- a/cogs/staff_site.py
+++ b/cogs/staff_site.py
@@ -12,17 +12,17 @@ from utils.time import time_took
 
 
 def bot_log_embed(ctx, bot_and_owner: Tuple[Union[discord.Member, int], Union[discord.Member, int]], *,
-                  reason: str = None):
+                  reason: str=None):
     def escape_markdown(txt: str):
         return discord.utils.escape_markdown(str(txt))
-    bot, bot_owner = bot_and_owner
-    bot_text = f"{escape_markdown(str(bot))} ({bot.id})" \
+    bot, bot_owner=bot_and_owner
+    bot_text=f"{escape_markdown(str(bot))} ({bot.id})" \
         if isinstance(bot, discord.Member) else escape_markdown(str(bot))
-    bot_owner_text = f"{escape_markdown(str(bot_owner))} ({bot_owner.id})" \
+    bot_owner_text=f"{escape_markdown(str(bot_owner))} ({bot_owner.id})" \
         if isinstance(bot_owner, discord.Member) else escape_markdown(str(bot_owner))
 
-    command_author = f"{escape_markdown(ctx.author)} | ({ctx.author.id})"
-    embed_stuff_dict = {
+    command_author=f"{escape_markdown(ctx.author)} | ({ctx.author.id})"
+    embed_stuff_dict={
         "deny": ("Bot denied", discord.Color.red(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
                  f"**Reviewer:** {command_author}", str(reason)),
         "delete": ("Bot deleted", discord.Color.red(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
@@ -30,133 +30,133 @@ def bot_log_embed(ctx, bot_and_owner: Tuple[Union[discord.Member, int], Union[di
         "approve": ("Bot approved", discord.Color.green(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
                     f"**Reviewer:** {command_author}", None)
     }
-    title, color, description, command_invoker, reason = embed_stuff_dict.get(str(ctx.command.name))
-    reason = f"**Reason:** {reason}" if reason is not None else ''
-    emb = discord.Embed(
-        title = title,
-        description = f"{description}\n\n{command_invoker}\n{reason}",
-        colour = color
+    title, color, description, command_invoker, reason=embed_stuff_dict.get(str(ctx.command.name))
+    reason=f"**Reason:** {reason}" if reason is not None else ''
+    emb=discord.Embed(
+        title=title,
+        description=f"{description}\n\n{command_invoker}\n{reason}",
+        colour=color
     )
     return emb
 
 
 class Staff(commands.Cog):
     def __init__(self, bot):
-        self.bot = bot
-        self.translator = googletrans.Translator()
+        self.bot=bot
+        self.translator=googletrans.Translator()
 
-    @commands.has_permissions(kick_members = True)
-    @commands.group(invoke_without_command = True, aliases = ["q"])
+    @commands.has_permissions(kick_members=True)
+    @commands.group(invoke_without_command=True, aliases=["q"])
     async def queue(self, ctx):
-        bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE approved = False AND denied = False")
+        bots=await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE approved=False AND denied=False")
         if not bots:
             await ctx.send("There are no bots in the queue")
             return
 
-        test_categories = (self.bot.get_cog("Events")).test_categories
-        listed_bots = []
+        test_categories=(self.bot.get_cog("Events")).test_categories
+        listed_bots=[]
         for x in bots:
             if x['id'] in test_categories.keys():
-                testing_category = self.bot.verification_guild.get_channel(test_categories[x['id']])
+                testing_category=self.bot.verification_guild.get_channel(test_categories[x['id']])
                 if not testing_category:
                     pass
-                testing_channel = discord.utils.get(testing_category.text_channels, name = "testing")
-                category_created_at = testing_category.created_at.replace(tzinfo = datetime.timezone.utc)
-                too_long = time_took(dt = category_created_at, only_hours = True,
-                                     now_dt = datetime.datetime.utcnow().replace(tzinfo = datetime.timezone.utc))
+                testing_channel=discord.utils.get(testing_category.text_channels, name="testing")
+                category_created_at=testing_category.created_at.replace(tzinfo=datetime.timezone.utc)
+                too_long=time_took(dt=category_created_at, only_hours=True,
+                                     now_dt=datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc))
                 if int(too_long) >= 6:
-                    too_long = f"|| {int(too_long)}+ hours in testing ⚠️"
+                    too_long=f"|| {int(too_long)}+ hours in testing ⚠️"
                 else:
-                    too_long = ""
+                    too_long=""
 
-                being_tested = f"(being tested in {testing_category.name} | {testing_channel.mention})"
+                being_tested=f"(being tested in {testing_category.name} | {testing_channel.mention})"
                 listed_bots.append(f"~~{x['username']}~~ {being_tested} {too_long}")
             else:
-                too_long = time_took(dt = x['added'], only_hours = True,
-                                     now_dt = datetime.datetime.utcnow().replace(tzinfo = datetime.timezone.utc))
+                too_long=time_took(dt=x['added'], only_hours=True,
+                                     now_dt=datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc))
                 if int(too_long) >= 2:
-                    too_long = f"|| {int(too_long)}+ hours in queue ⚠️"
+                    too_long=f"|| {int(too_long)}+ hours in queue ⚠️"
                 else:
-                    too_long = ""
-                invite = str(
+                    too_long=""
+                invite=str(
                     discord.utils.oauth_url(x['id'],
-                                            guild = self.bot.verification_guild)) + "&disable_guild_select=true"
+                                            guild=self.bot.verification_guild)) + "&disable_guild_select=true"
                 listed_bots.append(f"{x['username']} [Invite]({invite}) {too_long}")
 
-        embed = discord.Embed(
-            title = "Queue",
-            url = "https://blist.xyz/staff#verification",
-            description = '\n'.join(listed_bots) if listed_bots else "All Clear",
-            color = discord.Color.blurple()
+        embed=discord.Embed(
+            title="Queue",
+            url="https://blist.xyz/staff#verification",
+            description='\n'.join(listed_bots) if listed_bots else "All Clear",
+            color=discord.Color.blurple()
         )
-        await ctx.send(embed = embed)
+        await ctx.send(embed=embed)
 
     @checks.main_guild_only()
-    @queue.command(aliases = ["c"])
+    @queue.command(aliases=["c"])
     async def certification(self, ctx):
-        bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE awaiting_certification = True")
+        bots=await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE awaiting_certification=True")
         if bots is None:
             await ctx.send("There are no bots in the certification queue")
             return
 
-        listed_bots = []
+        listed_bots=[]
         for x in bots:
             listed_bots.append(f"{x['username']} | Added: {x['added']}")
 
-        embed = discord.Embed(
-            title = "Certification Queue",
-            description = '\n'.join(listed_bots) if listed_bots else "All Clear",
-            color = discord.Color.blurple()
+        embed=discord.Embed(
+            title="Certification Queue",
+            description='\n'.join(listed_bots) if listed_bots else "All Clear",
+            color=discord.Color.blurple()
         )
-        await ctx.send(embed = embed)
+        await ctx.send(embed=embed)
 
     @checks.verification_guild_only()
-    @commands.has_permissions(kick_members = True)
-    @commands.command(aliases = ['accept'])
+    @commands.has_permissions(kick_members=True)
+    @commands.command(aliases=['accept'])
     async def approve(self, ctx, *, bot: discord.Member):
         if not bot.bot:
             await ctx.send("This is not a bot.")
             return
 
-        bots = await self.bot.pool.fetchrow(
-            "SELECT main_owner, referred_by FROM main_site_bot WHERE approved = False AND denied = False AND id = $1",
+        bots=await self.bot.pool.fetchrow(
+            "SELECT main_owner, referred_by FROM main_site_bot WHERE approved=False AND denied=False AND id=$1",
             bot.id)
         if not bots:
             await ctx.send("This bot is not awaiting approval")
             return
 
-        owner = self.bot.main_guild.get_member(bots["main_owner"])
+        owner=self.bot.main_guild.get_member(bots["main_owner"])
         if not owner:
             await ctx.send(f"{ctx.author.mention}, The owner of this bot has left the main server, deny it!")
             return
 
         if bots["referred_by"] != "":
-            user_id = await self.bot.pool.fetchval("SELECT id FROM main_site_user WHERE referrer_code  = $1",
+            user_id=await self.bot.pool.fetchval("SELECT id FROM main_site_user WHERE referrer_code =$1",
                                                    bots["referred_by"])
             if user_id:
-                await self.bot.pool.execute("UPDATE main_site_user SET referrals = referrals + 1 WHERE id = $1",
+                await self.bot.pool.execute("UPDATE main_site_user SET referrals=referrals + 1 WHERE id=$1",
                                             user_id)
 
-        await self.bot.pool.execute("UPDATE main_site_user SET developer = True WHERE id = $1", bots["main_owner"])
-        await self.bot.pool.execute("UPDATE main_site_bot SET approved = True WHERE id = $1", bot.id)
-        await self.bot.mod_pool.execute("UPDATE staff SET approved = approved + 1 WHERE userid = $1", ctx.author.id)
+        await self.bot.pool.execute("UPDATE main_site_user SET developer=True WHERE id=$1", bots["main_owner"])
+        await self.bot.pool.execute("UPDATE main_site_bot SET approved=True WHERE id=$1", bot.id)
+        await self.bot.mod_pool.execute("UPDATE staff SET approved=approved + 1 WHERE userid=$1", ctx.author.id)
 
-        queued_bots = await self.bot.pool.fetchval(
-            "SELECT COUNT(*) FROM main_site_bot WHERE approved = False AND denied = False")
-        invite = str(discord.utils.oauth_url(
-            bot.id, guild = self.bot.main_guild)) + "&disable_guild_select=true"
-        embed = discord.Embed(
-            title = f"Approved {bot.name}",
-            description = f"[Invite!]({invite})\n\nThere are {queued_bots} bot(s) in the queue.",
-            color = discord.Color.blurple()
+        queued_bots=await self.bot.pool.fetchval(
+            "SELECT COUNT(*) FROM main_site_bot WHERE approved=False AND denied=False")
+        invite=str(discord.utils.oauth_url(
+            bot.id, guild=self.bot.main_guild)) + "&disable_guild_select=true"
+        embed=discord.Embed(
+            title=f"Approved {bot.name}",
+            description=f"[Invite!]({invite})\n\nThere are {queued_bots} bot(s) in the queue.",
+            color=discord.Color.blurple()
         )
         await self.bot.verification_guild.get_channel(763183376311517215).send(
-            content = ctx.author.mention, embed = embed)
+            content=ctx.author.mention, embed=embed)
 
-        em = bot_log_embed(ctx, (bot, owner))
-        await self.bot.get_channel(716446098859884625).send(embed = em)
+        em=bot_log_embed(ctx, (bot, owner))
+        await self.bot.get_channel(716446098859884625).send(embed=em)
 
-        dev_role = self.bot.main_guild.get_role(716684805286133840)
+        dev_role=self.bot.main_guild.get_role(716684805286133840)
 
         try:
             await owner.send(f"Your bot `{bot}` was approved!")
@@ -169,18 +169,18 @@ class Staff(commands.Cog):
             pass
 
         await bot.kick()
-        bots = await self.bot.pool.fetchval("SELECT COUNT(*) FROM main_site_bot")
-        await self.bot.change_presence(activity = discord.Game(name = f"Watching {bots} bots"))
+        bots=await self.bot.pool.fetchval("SELECT COUNT(*) FROM main_site_bot")
+        await self.bot.change_presence(activity=discord.Game(name=f"Watching {bots} bots"))
 
-    @commands.has_permissions(kick_members = True)
+    @commands.has_permissions(kick_members=True)
     @commands.command()
     async def deny(self, ctx, bot: Union[discord.Member, discord.User]):
         if not bot.bot:
             await ctx.send("This user is not a bot")
             return
 
-        bots = await self.bot.pool.fetchval(
-            "SELECT main_owner FROM main_site_bot WHERE approved = False AND denied = False AND id = $1", bot.id)
+        bots=await self.bot.pool.fetchval(
+            "SELECT main_owner FROM main_site_bot WHERE approved=False AND denied=False AND id=$1", bot.id)
         if not bots:
             await ctx.send("This bot is not awaiting approval")
             return
@@ -188,7 +188,7 @@ class Staff(commands.Cog):
         def wait_for_check(m):
             return m.channel.id == ctx.channel.id and m.author.id == ctx.author.id
 
-        preset_reasons = [
+        preset_reasons=[
             "Bot was offline when we tried to test it.",
             "The bot's description is poor quality. The description must be improved before resubmission.",
             "The avatar of the bot is considered NSFW.",
@@ -207,68 +207,68 @@ class Staff(commands.Cog):
             "The bot owner did not respond or complete fixes within the time frame given."
         ]
 
-        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start = 1)])
-        embed = discord.Embed(
-            title = f"Denying {bot.name}",
-            description = join_preset_reasons,
-            color = discord.Color.red()
+        join_preset_reasons="\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start=1)])
+        embed=discord.Embed(
+            title=f"Denying {bot.name}",
+            description=join_preset_reasons,
+            color=discord.Color.red()
         )
-        embed.set_footer(text = "You have 20 seconds to provide a valid reason number or type your own reason.")
-        await ctx.send(embed = embed)
+        embed.set_footer(text="You have 20 seconds to provide a valid reason number or type your own reason.")
+        await ctx.send(embed=embed)
 
         try:
-            msg = await self.bot.wait_for("message", timeout = 20.0, check = wait_for_check)
+            msg=await self.bot.wait_for("message", timeout=20.0, check=wait_for_check)
         except asyncio.TimeoutError:
             return await ctx.send(
                 "You did not provide a reason number or custom reason in time. The command was cancelled.")
         else:
             if msg.content.isdigit():
                 try:
-                    reason = preset_reasons[int(msg.content) - 1]
+                    reason=preset_reasons[int(msg.content) - 1]
                 except KeyError:
                     return await ctx.send(f"{msg.content} is not valid reason number. The command was cancelled.")
             else:
-                reason = msg.content  # custom reason
+                reason=msg.content  # custom reason
 
-        await self.bot.mod_pool.execute("UPDATE staff SET denied = denied + 1 WHERE userid = $1", ctx.author.id)
+        await self.bot.mod_pool.execute("UPDATE staff SET denied=denied + 1 WHERE userid=$1", ctx.author.id)
 
         try:
-            owner = self.bot.main_guild.get_member(bots)
+            owner=self.bot.main_guild.get_member(bots)
             await owner.send(f"Your bot `{bot}` was denied!")
         except (discord.Forbidden, AttributeError):
             pass
 
-        await self.bot.pool.execute("UPDATE main_site_bot SET denied = True WHERE id = $1", bot.id)
-        embed = discord.Embed(
-            description = f"Denied {bot.name}", color = discord.Color.red())
-        await ctx.send(embed = embed)
+        await self.bot.pool.execute("UPDATE main_site_bot SET denied=True WHERE id=$1", bot.id)
+        embed=discord.Embed(
+            description=f"Denied {bot.name}", color=discord.Color.red())
+        await ctx.send(embed=embed)
 
-        bot_owner = self.bot.main_guild.get_member(bots)
-        bot_owner = bot_owner if bot_owner else int(bots)
-        em = bot_log_embed(ctx, (bot, bot_owner), reason = str(reason))
-        await self.bot.get_channel(716446098859884625).send(embed = em)
+        bot_owner=self.bot.main_guild.get_member(bots)
+        bot_owner=bot_owner if bot_owner else int(bots)
+        em=bot_log_embed(ctx, (bot, bot_owner), reason=str(reason))
+        await self.bot.get_channel(716446098859884625).send(embed=em)
 
         try:
-            await bot.kick(reason = "Bot Denied")
+            await bot.kick(reason="Bot Denied")
         except Exception:
             await ctx.send("Couldn't kick bot")
 
     @checks.main_guild_only()
-    @commands.has_permissions(kick_members = True)
+    @commands.has_permissions(kick_members=True)
     @commands.command()
     async def delete(self, ctx, bot: Union[discord.Member, int]):
-        bot_user = None
+        bot_user=None
         if isinstance(bot, discord.Member):
-            bot_user = bot
+            bot_user=bot
         if isinstance(bot, int):
-            bot_user = self.bot.main_guild.get_member(bot)
+            bot_user=self.bot.main_guild.get_member(bot)
 
         if bot_user and not bot_user.bot:
             await ctx.send("That is not a bot.")
             return
 
-        bots = await self.bot.pool.fetchrow(
-            "SELECT main_owner, username, certified, discriminator FROM main_site_bot WHERE approved = True AND id = $1",
+        bots=await self.bot.pool.fetchrow(
+            "SELECT main_owner, username, certified, discriminator FROM main_site_bot WHERE approved=True AND id=$1",
             bot_user.id if bot_user else bot)
         if not bots:
             await ctx.send("This bot is not on the list")
@@ -277,7 +277,7 @@ class Staff(commands.Cog):
         def wait_for_check(m):
             return m.channel.id == ctx.channel.id and m.author.id == ctx.author.id
 
-        preset_reasons = [
+        preset_reasons=[
             "Bot left the main server",
             "Owner left the main server",
             "Owner was banned from the main server",
@@ -288,73 +288,73 @@ class Staff(commands.Cog):
             "Bot sent unwanted spam",
         ]
 
-        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start = 1)])
-        embed = discord.Embed(
-            title = f"Deleting {bot.name}",
-            description = join_preset_reasons,
-            color = discord.Color.red()
+        join_preset_reasons="\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start=1)])
+        embed=discord.Embed(
+            title=f"Deleting {bot.name}",
+            description=join_preset_reasons,
+            color=discord.Color.red()
         )
-        embed.set_footer(text = "You have 20 seconds to provide a valid reason number or type your own reason.")
-        await ctx.send(embed = embed)
+        embed.set_footer(text="You have 20 seconds to provide a valid reason number or type your own reason.")
+        await ctx.send(embed=embed)
 
         try:
-            message = await self.bot.wait_for("message", timeout = 20.0, check = wait_for_check)
+            message=await self.bot.wait_for("message", timeout=20.0, check=wait_for_check)
         except asyncio.TimeoutError:
             return await ctx.send(
                 "You did not provide a reason number or custom reason in time. The command was cancelled.")
         else:
             if message.content.isdigit():
                 try:
-                    reason = preset_reasons[int(message.content) - 1]
+                    reason=preset_reasons[int(message.content) - 1]
                 except KeyError:
                     return await ctx.send(f"{message.content} is not valid reason number. The command was cancelled.")
             else:
-                reason = message.content  # custom reason
+                reason=message.content  # custom reason
 
-        bot_db = await self.bot.pool.fetchval("SELECT unique_id FROM main_site_bot WHERE id = $1",
+        bot_db=await self.bot.pool.fetchval("SELECT unique_id FROM main_site_bot WHERE id=$1",
                                               bot_user.id if bot_user else bot)
-        await self.bot.pool.execute("DELETE FROM main_site_vote WHERE bot_id = $1", bot_db)
-        await self.bot.pool.execute("DELETE FROM main_site_review WHERE bot_id = $1", bot_db)
-        await self.bot.pool.execute("DELETE FROM main_site_auditlogaction WHERE bot_id = $1", bot_db)
-        await self.bot.pool.execute("DELETE FROM main_site_bot WHERE id = $1", bot_user.id if bot_user else bot)
+        await self.bot.pool.execute("DELETE FROM main_site_vote WHERE bot_id=$1", bot_db)
+        await self.bot.pool.execute("DELETE FROM main_site_review WHERE bot_id=$1", bot_db)
+        await self.bot.pool.execute("DELETE FROM main_site_auditlogaction WHERE bot_id=$1", bot_db)
+        await self.bot.pool.execute("DELETE FROM main_site_bot WHERE id=$1", bot_user.id if bot_user else bot)
 
-        embed = discord.Embed(
-            description = f"Deleted {bots['username']}", color = discord.Color.red())
-        await ctx.send(embed = embed)
+        embed=discord.Embed(
+            description=f"Deleted {bots['username']}", color=discord.Color.red())
+        await ctx.send(embed=embed)
 
-        bot_owner = self.bot.main_guild.get_member(bots['main_owner'])
-        bot_owner = bot_owner if bot_owner else int(bots['main_owner'])
-        bot_member = self.bot.main_guild.get_member(bots['id']) or self.bot.verification_guild.get_member(bots['id'])
-        bot_member = bot_member if bot_member else f"{bots['username']}#{bots['discriminator']} ({bots['id']})"
-        em = bot_log_embed(ctx, (bot_member, bot_owner), reason = str(reason))
-        await self.bot.get_channel(716446098859884625).send(embed = em)
+        bot_owner=self.bot.main_guild.get_member(bots['main_owner'])
+        bot_owner=bot_owner if bot_owner else int(bots['main_owner'])
+        bot_member=self.bot.main_guild.get_member(bots['id']) or self.bot.verification_guild.get_member(bots['id'])
+        bot_member=bot_member if bot_member else f"{bots['username']}#{bots['discriminator']} ({bots['id']})"
+        em=bot_log_embed(ctx, (bot_member, bot_owner), reason=str(reason))
+        await self.bot.get_channel(716446098859884625).send(embed=em)
 
         if bot_owner and bots['certified'] is True:
-            certified_dev_role = ctx.guild.get_role(716724317207003206)
+            certified_dev_role=ctx.guild.get_role(716724317207003206)
             await bot_owner.remove_roles(certified_dev_role)
 
-        has_other_bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE main_owner = $1",
+        has_other_bots=await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE main_owner=$1",
                                                    bots['main_owner'])
         if not has_other_bots and bot_owner:
-            dev_role = ctx.guild.get_role(716684805286133840)
+            dev_role=ctx.guild.get_role(716684805286133840)
             await bot_owner.remove_roles(dev_role)
-            await self.bot.pool.execute("UPDATE main_site_user SET developer = False WHERE id = $1",
+            await self.bot.pool.execute("UPDATE main_site_user SET developer=False WHERE id=$1",
                                         bots['main_owner'])
 
         if bot_user is not None:
-            await bot_user.kick(reason = "Bot Deleted")
+            await bot_user.kick(reason="Bot Deleted")
 
-    @commands.has_permissions(kick_members = True)
+    @commands.has_permissions(kick_members=True)
     @commands.command()
     async def say(self, ctx, *, msg: commands.clean_content):
         """Make blist repeat what you said"""
         await ctx.send(msg)
 
-    @flags.add_flag("--to", type = str, default = "en")
-    @flags.add_flag("--from", type = str, default = "auto")
-    @flags.add_flag("message", nargs = "+")
-    @commands.has_permissions(kick_members = True)
-    @commands.command(hidden = True, aliases = ["t"], cls = flags.FlagCommand)
+    @flags.add_flag("--to", type=str, default="en")
+    @flags.add_flag("--from", type=str, default="auto")
+    @flags.add_flag("message", nargs="+")
+    @commands.has_permissions(kick_members=True)
+    @commands.command(hidden=True, aliases=["t"], cls=flags.FlagCommand)
     async def translate(self, ctx, **arguments):
         """
         Translates a message to English (default) using Google translate.
@@ -363,36 +363,36 @@ class Staff(commands.Cog):
         --to | translate text to x language. Example: `b!translate cool --to en`
         --from | translate text from x language. Example: `b!translate cool --from nl`
         """
-        message = ' '.join(arguments['message'])
+        message=' '.join(arguments['message'])
         try:
-            translated = self.translator.translate(
-                message, dest = arguments['to'], src = arguments['from'])
+            translated=self.translator.translate(
+                message, dest=arguments['to'], src=arguments['from'])
         except ValueError:
             return await ctx.send(
-                embed = discord.Embed(description = "That is not a valid language!", color = discord.Color.red()))
+                embed=discord.Embed(description="That is not a valid language!", color=discord.Color.red()))
 
-        src = googletrans.LANGUAGES.get(
+        src=googletrans.LANGUAGES.get(
             translated.src, '(auto-detected)').title()
-        dest = googletrans.LANGUAGES.get(translated.dest, 'Unknown').title()
-        embed = discord.Embed(color = discord.Color.blurple())
-        embed.add_field(name = f"{src} ({translated.src})",
-                        value = translated.origin, inline = False)
-        embed.add_field(name = f"{dest} ({translated.dest})",
-                        value = translated.text, inline = False)
-        await ctx.send(embed = embed)
+        dest=googletrans.LANGUAGES.get(translated.dest, 'Unknown').title()
+        embed=discord.Embed(color=discord.Color.blurple())
+        embed.add_field(name=f"{src} ({translated.src})",
+                        value=translated.origin, inline=False)
+        embed.add_field(name=f"{dest} ({translated.dest})",
+                        value=translated.text, inline=False)
+        await ctx.send(embed=embed)
 
     @commands.command()
-    async def staff(self, ctx, member: discord.Member = None):
+    async def staff(self, ctx, member: discord.Member=None):
         if not member:
-            member = ctx.author
+            member=ctx.author
 
-        query = await self.bot.mod_pool.fetch("SELECT * FROM staff WHERE userid = $1", member.id)
+        query=await self.bot.mod_pool.fetch("SELECT * FROM staff WHERE userid=$1", member.id)
         if not query:
             return await ctx.send("This user is not staff!")
-        query = query[0]
-        embed = discord.Embed(
-            color = discord.Color.blurple(),
-            description = wrap(
+        query=query[0]
+        embed=discord.Embed(
+            color=discord.Color.blurple(),
+            description=wrap(
                 f"""
                 >>> Staff Since: ``{query['joinedat'].strftime("%F")}``
                 Bots Approved: ``{query['approved']}``
@@ -403,64 +403,64 @@ class Staff(commands.Cog):
                 """
             )
         )
-        embed.set_author(name = member, icon_url = str(member.avatar_url))
-        await ctx.send(embed = embed)
+        embed.set_author(name=member, icon_url=str(member.avatar_url))
+        await ctx.send(embed=embed)
 
-    @commands.has_permissions(kick_members = True)
+    @commands.has_permissions(kick_members=True)
     @checks.verification_guild_only()
-    @commands.command(aliases = ['lock'])
-    async def hold(self, ctx, message: typing.Optional[discord.Message] = None, *, reason: str):
+    @commands.command(aliases=['lock'])
+    async def hold(self, ctx, message: typing.Optional[discord.Message]=None, *, reason: str):
         """ Waiting on a bot owner to fix their bot? Use this!
         You can also include the message url of the message to the owner like so, `b!hold URLHERE reason here`
         Or use the command with only a reason, `b!hold reason here`
         """
-        em = discord.Embed(
-            title = str(reason),
-            colour = discord.Color.blurple(),
-            timestamp = ctx.message.created_at
+        em=discord.Embed(
+            title=str(reason),
+            colour=discord.Color.blurple(),
+            timestamp=ctx.message.created_at
         )
-        em.set_author(name = ctx.author.name, icon_url = ctx.author.avatar_url)
+        em.set_author(name=ctx.author.name, icon_url=ctx.author.avatar_url)
         if message:
-            em.description = f"[message link]({message.jump_url})"
+            em.description=f"[message link]({message.jump_url})"
 
-        staff_role = ctx.channel.category.overwrites_for(ctx.guild.get_role(763177553636098082))
-        staff_role.send_messages = False
-        everyone = ctx.channel.category.overwrites_for(ctx.guild.default_role)
-        everyone.send_messages = False
-        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = staff_role,
-                                                   reason = f"hold review for {reason}")
-        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = everyone,
-                                                   reason = f"hold review for {reason}")
-        await ctx.channel.category.set_permissions(ctx.author, reason = f"hold review for {reason}",
-                                                   send_messages = True)
+        staff_role=ctx.channel.category.overwrites_for(ctx.guild.get_role(763177553636098082))
+        staff_role.send_messages=False
+        everyone=ctx.channel.category.overwrites_for(ctx.guild.default_role)
+        everyone.send_messages=False
+        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite=staff_role,
+                                                   reason=f"hold review for {reason}")
+        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite=everyone,
+                                                   reason=f"hold review for {reason}")
+        await ctx.channel.category.set_permissions(ctx.author, reason=f"hold review for {reason}",
+                                                   send_messages=True)
 
-        msg = await ctx.send(embed = em)
+        msg=await ctx.send(embed=em)
         await ctx.message.delete()
         await msg.pin()
 
-    @commands.has_permissions(kick_members = True)
+    @commands.has_permissions(kick_members=True)
     @checks.verification_guild_only()
-    @commands.command(aliases = ['unlock'])
+    @commands.command(aliases=['unlock'])
     async def unhold(self, ctx):
         """Unhold the channel to start reviewing a bot again."""
-        em = discord.Embed(
-            title = "Unlocked the channel, you can continue.",
-            colour = discord.Color.blurple()
+        em=discord.Embed(
+            title="Unlocked the channel, you can continue.",
+            colour=discord.Color.blurple()
         )
-        em.set_author(name = ctx.author.name, icon_url = ctx.author.avatar_url)
+        em.set_author(name=ctx.author.name, icon_url=ctx.author.avatar_url)
 
-        staff_role = ctx.channel.category.overwrites_for(ctx.guild.get_role(763177553636098082))
-        staff_role.send_messages = None
-        everyone = ctx.channel.category.overwrites_for(ctx.guild.default_role)
-        everyone.send_messages = None
-        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = staff_role,
-                                                   reason = "unlocked")
-        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = everyone, reason = "unlocked")
-        await ctx.channel.category.set_permissions(ctx.author, overwrite = None, reason = "unlocked")
+        staff_role=ctx.channel.category.overwrites_for(ctx.guild.get_role(763177553636098082))
+        staff_role.send_messages=None
+        everyone=ctx.channel.category.overwrites_for(ctx.guild.default_role)
+        everyone.send_messages=None
+        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite=staff_role,
+                                                   reason="unlocked")
+        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite=everyone, reason="unlocked")
+        await ctx.channel.category.set_permissions(ctx.author, overwrite=None, reason="unlocked")
 
-        await ctx.send(embed = em)
+        await ctx.send(embed=em)
         await ctx.message.delete()
-        channel_pins_hold_embeds = [x for x in await ctx.channel.pins() if x.embeds and x.embeds[0].author]
+        channel_pins_hold_embeds=[x for x in await ctx.channel.pins() if x.embeds and x.embeds[0].author]
         if not channel_pins_hold_embeds:
             return
 

--- a/cogs/staff_site.py
+++ b/cogs/staff_site.py
@@ -420,6 +420,7 @@ class Staff(commands.Cog):
             timestamp=ctx.message.created_at
         )
         em.set_author(name=ctx.author.name, icon_url=ctx.author.avatar_url)
+        em.set_footer(text = "don't forget to use b!unlock, only you can send messages now.")
         if message:
             em.description=f"[message link]({message.jump_url})"
 

--- a/cogs/staff_site.py
+++ b/cogs/staff_site.py
@@ -1,6 +1,5 @@
-import datetime
 from textwrap import dedent as wrap
-from typing import Union, Tuple, Dict
+from typing import Union
 
 import discord
 import googletrans
@@ -8,36 +7,6 @@ import asyncio
 import typing
 from discord.ext import commands, flags
 from utils import checks
-from utils.time import time_took
-
-
-def bot_log_embed(ctx, bot_and_owner: Tuple[Union[discord.Member, int], Union[discord.Member, int]], *,
-                  reason: str = None):
-    def escape_markdown(txt: str):
-        return discord.utils.escape_markdown(str(txt))
-    bot, bot_owner = bot_and_owner
-    bot_text = f"{escape_markdown(str(bot))} ({bot.id})" \
-        if isinstance(bot, discord.Member) else escape_markdown(str(bot))
-    bot_owner_text = f"{escape_markdown(str(bot_owner))} ({bot_owner.id})" \
-        if isinstance(bot_owner, discord.Member) else escape_markdown(str(bot_owner))
-
-    command_author = f"{escape_markdown(ctx.author)} | ({ctx.author.id})"
-    embed_stuff_dict = {
-        "deny": ("Bot denied", discord.Color.red(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
-                 f"**Reviewer:** {command_author}", str(reason)),
-        "delete": ("Bot deleted", discord.Color.red(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
-                   f"**Author:** {command_author}", str(reason)),
-        "approve": ("Bot approved", discord.Color.green(), f"**Bot:** {bot_text}\n**Owner:** {bot_owner_text}",
-                    f"**Reviewer:** {command_author}", None)
-    }
-    title, color, description, command_invoker, reason = embed_stuff_dict.get(str(ctx.command.name))
-    reason = f"**Reason:** {reason}" if reason is not None else ''
-    emb = discord.Embed(
-        title = title,
-        description = f"{description}\n\n{command_invoker}\n{reason}",
-        colour = color
-    )
-    return emb
 
 
 class Staff(commands.Cog):
@@ -45,8 +14,8 @@ class Staff(commands.Cog):
         self.bot = bot
         self.translator = googletrans.Translator()
 
-    @commands.has_permissions(kick_members = True)
-    @commands.group(invoke_without_command = True, aliases = ["q"])
+    @commands.has_permissions(kick_members=True)
+    @commands.group(invoke_without_command=True, aliases=["q"])
     async def queue(self, ctx):
         bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE approved = False AND denied = False")
         if not bots:
@@ -58,41 +27,24 @@ class Staff(commands.Cog):
         for x in bots:
             if x['id'] in test_categories.keys():
                 testing_category = self.bot.verification_guild.get_channel(test_categories[x['id']])
-                if not testing_category:
-                    pass
                 testing_channel = discord.utils.get(testing_category.text_channels, name = "testing")
-                category_created_at = testing_category.created_at.replace(tzinfo = datetime.timezone.utc)
-                too_long = time_took(dt = category_created_at, only_hours = True,
-                                     now_dt = datetime.datetime.utcnow().replace(tzinfo = datetime.timezone.utc))
-                if int(too_long) >= 6:
-                    too_long = f"|| {int(too_long)}+ hours in testing ⚠️"
-                else:
-                    too_long = ""
-
                 being_tested = f"(being tested in {testing_category.name} | {testing_channel.mention})"
-                listed_bots.append(f"~~{x['username']}~~ {being_tested} {too_long}")
+                listed_bots.append(f"~~{x['username']}~~ {being_tested}")
             else:
-                too_long = time_took(dt = x['added'], only_hours = True,
-                                     now_dt = datetime.datetime.utcnow().replace(tzinfo = datetime.timezone.utc))
-                if int(too_long) >= 2:
-                    too_long = f"|| {int(too_long)}+ hours in queue ⚠️"
-                else:
-                    too_long = ""
                 invite = str(
-                    discord.utils.oauth_url(x['id'],
-                                            guild = self.bot.verification_guild)) + "&disable_guild_select=true"
-                listed_bots.append(f"{x['username']} [Invite]({invite}) {too_long}")
+                    discord.utils.oauth_url(x['id'], guild=self.bot.verification_guild)) + "&disable_guild_select=true"
+                listed_bots.append(f"{x['username']} [Invite]({invite})")
 
         embed = discord.Embed(
-            title = "Queue",
-            url = "https://blist.xyz/staff#verification",
-            description = '\n'.join(listed_bots) if listed_bots else "All Clear",
-            color = discord.Color.blurple()
+            title="Queue",
+            url="https://blist.xyz/staff#verification",
+            description='\n'.join(listed_bots) if listed_bots else "All Clear",
+            color=discord.Color.blurple()
         )
-        await ctx.send(embed = embed)
+        await ctx.send(embed=embed)
 
     @checks.main_guild_only()
-    @queue.command(aliases = ["c"])
+    @queue.command(aliases=["c"])
     async def certification(self, ctx):
         bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE awaiting_certification = True")
         if bots is None:
@@ -104,23 +56,22 @@ class Staff(commands.Cog):
             listed_bots.append(f"{x['username']} | Added: {x['added']}")
 
         embed = discord.Embed(
-            title = "Certification Queue",
-            description = '\n'.join(listed_bots) if listed_bots else "All Clear",
-            color = discord.Color.blurple()
+            title="Certification Queue",
+            description='\n'.join(listed_bots) if listed_bots else "All Clear",
+            color=discord.Color.blurple()
         )
-        await ctx.send(embed = embed)
+        await ctx.send(embed=embed)
 
     @checks.verification_guild_only()
-    @commands.has_permissions(kick_members = True)
-    @commands.command(aliases = ['accept'])
+    @commands.has_permissions(kick_members=True)
+    @commands.command()
     async def approve(self, ctx, *, bot: discord.Member):
         if not bot.bot:
             await ctx.send("This is not a bot.")
             return
 
         bots = await self.bot.pool.fetchrow(
-            "SELECT main_owner, referred_by FROM main_site_bot WHERE approved = False AND denied = False AND id = $1",
-            bot.id)
+            "SELECT main_owner, referred_by FROM main_site_bot WHERE approved = False AND denied = False AND id = $1", bot.id)
         if not bots:
             await ctx.send("This bot is not awaiting approval")
             return
@@ -131,11 +82,9 @@ class Staff(commands.Cog):
             return
 
         if bots["referred_by"] != "":
-            user_id = await self.bot.pool.fetchval("SELECT id FROM main_site_user WHERE referrer_code  = $1",
-                                                   bots["referred_by"])
+            user_id = await self.bot.pool.fetchval("SELECT id FROM main_site_user WHERE referrer_code  = $1", bots["referred_by"])
             if user_id:
-                await self.bot.pool.execute("UPDATE main_site_user SET referrals = referrals + 1 WHERE id = $1",
-                                            user_id)
+                await self.bot.pool.execute("UPDATE main_site_user SET referrals = referrals + 1 WHERE id = $1", user_id)
 
         await self.bot.pool.execute("UPDATE main_site_user SET developer = True WHERE id = $1", bots["main_owner"])
         await self.bot.pool.execute("UPDATE main_site_bot SET approved = True WHERE id = $1", bot.id)
@@ -144,17 +93,17 @@ class Staff(commands.Cog):
         queued_bots = await self.bot.pool.fetchval(
             "SELECT COUNT(*) FROM main_site_bot WHERE approved = False AND denied = False")
         invite = str(discord.utils.oauth_url(
-            bot.id, guild = self.bot.main_guild)) + "&disable_guild_select=true"
+            bot.id, guild=self.bot.main_guild)) + "&disable_guild_select=true"
         embed = discord.Embed(
-            title = f"Approved {bot.name}",
-            description = f"[Invite!]({invite})\n\nThere are {queued_bots} bot(s) in the queue.",
-            color = discord.Color.blurple()
+            title=f"Approved {bot.name}",
+            description=f"[Invite!]({invite})\n\nThere are {queued_bots} bot(s) in the queue.",
+            color=discord.Color.blurple()
         )
-        await self.bot.verification_guild.get_channel(763183376311517215).send(
-            content = ctx.author.mention, embed = embed)
-
-        em = bot_log_embed(ctx, (bot, owner))
-        await self.bot.get_channel(716446098859884625).send(embed = em)
+        await self.bot.verification_guild.get_channel(763183376311517215).send(content=ctx.author.mention, embed=embed)
+        em = discord.Embed(
+            description=f"``{bot}`` by ``{self.bot.main_guild.get_member(bots['main_owner'])}`` was approved by ``{ctx.author}``",
+            color=discord.Color.blurple())
+        await self.bot.get_channel(716446098859884625).send(embed=em)
 
         dev_role = self.bot.main_guild.get_role(716684805286133840)
 
@@ -170,9 +119,9 @@ class Staff(commands.Cog):
 
         await bot.kick()
         bots = await self.bot.pool.fetchval("SELECT COUNT(*) FROM main_site_bot")
-        await self.bot.change_presence(activity = discord.Game(name = f"Watching {bots} bots"))
+        await self.bot.change_presence(activity=discord.Game(name=f"Watching {bots} bots"))
 
-    @commands.has_permissions(kick_members = True)
+    @commands.has_permissions(kick_members=True)
     @commands.command()
     async def deny(self, ctx, bot: Union[discord.Member, discord.User]):
         if not bot.bot:
@@ -207,28 +156,25 @@ class Staff(commands.Cog):
             "The bot owner did not respond or complete fixes within the time frame given."
         ]
 
-        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start = 1)])
+        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start=1)])
         embed = discord.Embed(
-            title = f"Denying {bot.name}",
-            description = join_preset_reasons,
-            color = discord.Color.red()
+            title=f"Denying {bot.name}",
+            description=join_preset_reasons,
+            color=discord.Color.red()
         )
-        embed.set_footer(text = "You have 20 seconds to provide a valid reason number or type your own reason.")
-        await ctx.send(embed = embed)
+        embed.set_footer(text="You have 20 seconds to provide a valid reason number or type your own reason.")
+        await ctx.send(embed=embed)
 
         try:
-            msg = await self.bot.wait_for("message", timeout = 20.0, check = wait_for_check)
+            msg = await self.bot.wait_for("message", timeout=20.0, check=wait_for_check)
         except asyncio.TimeoutError:
-            return await ctx.send(
-                "You did not provide a reason number or custom reason in time. The command was cancelled.")
+            return await ctx.send("You did not provide a reason number or custom reason in time. The command was cancelled.")
         else:
+            if not msg.content.isdigit():
+                reason = msg.content # custom reason
+
             if msg.content.isdigit():
-                try:
-                    reason = preset_reasons[int(msg.content) - 1]
-                except KeyError:
-                    return await ctx.send(f"{msg.content} is not valid reason number. The command was cancelled.")
-            else:
-                reason = msg.content  # custom reason
+                reason = preset_reasons[int(msg.content)-1]
 
         await self.bot.mod_pool.execute("UPDATE staff SET denied = denied + 1 WHERE userid = $1", ctx.author.id)
 
@@ -240,21 +186,20 @@ class Staff(commands.Cog):
 
         await self.bot.pool.execute("UPDATE main_site_bot SET denied = True WHERE id = $1", bot.id)
         embed = discord.Embed(
-            description = f"Denied {bot.name}", color = discord.Color.red())
-        await ctx.send(embed = embed)
-
-        bot_owner = self.bot.main_guild.get_member(bots)
-        bot_owner = bot_owner if bot_owner else int(bots)
-        em = bot_log_embed(ctx, (bot, bot_owner), reason = str(reason))
-        await self.bot.get_channel(716446098859884625).send(embed = em)
-
+            description=f"Denied {bot.name}", color=discord.Color.red())
+        await ctx.send(embed=embed)
+        em = discord.Embed(
+            description=f"``{bot}`` by ``{self.bot.main_guild.get_member(bots)}`` was denied by ``{ctx.author}`` for: \n```{reason}```",
+            color=discord.Color.red())
+        await self.bot.get_channel(716446098859884625).send(embed=em)
         try:
-            await bot.kick(reason = "Bot Denied")
+            await bot.kick(reason="Bot Denied")
         except Exception:
             await ctx.send("Couldn't kick bot")
 
+
     @checks.main_guild_only()
-    @commands.has_permissions(kick_members = True)
+    @commands.has_permissions(kick_members=True)
     @commands.command()
     async def delete(self, ctx, bot: Union[discord.Member, int]):
         bot_user = None
@@ -268,13 +213,12 @@ class Staff(commands.Cog):
             return
 
         bots = await self.bot.pool.fetchrow(
-            "SELECT main_owner, username, certified, discriminator FROM main_site_bot WHERE approved = True AND id = $1",
-            bot_user.id if bot_user else bot)
+            "SELECT main_owner, username, certified, discriminator FROM main_site_bot WHERE approved = True AND id = $1", bot_user.id if bot_user else bot)
         if not bots:
             await ctx.send("This bot is not on the list")
             return
 
-        def wait_for_check(m):
+        def wait_for_check2(m):
             return m.channel.id == ctx.channel.id and m.author.id == ctx.author.id
 
         preset_reasons = [
@@ -288,73 +232,71 @@ class Staff(commands.Cog):
             "Bot sent unwanted spam",
         ]
 
-        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start = 1)])
+        join_preset_reasons = "\n".join([f"**{num}.** {rule}" for num, rule in enumerate(preset_reasons, start=1)])
         embed = discord.Embed(
-            title = f"Deleting {bot.name}",
-            description = join_preset_reasons,
-            color = discord.Color.red()
+            title=f"Deleting {bot.name}",
+            description=join_preset_reasons,
+            color=discord.Color.red()
         )
-        embed.set_footer(text = "You have 20 seconds to provide a valid reason number or type your own reason.")
-        await ctx.send(embed = embed)
+        embed.set_footer(text="You have 20 seconds to provide a valid reason number or type your own reason.")
+        await ctx.send(embed=embed)
 
         try:
-            message = await self.bot.wait_for("message", timeout = 20.0, check = wait_for_check)
+            message = await self.bot.wait_for("message", timeout=20.0, check=wait_for_check2)
         except asyncio.TimeoutError:
-            return await ctx.send(
-                "You did not provide a reason number or custom reason in time. The command was cancelled.")
+            return await ctx.send("You did not provide a reason number or custom reason in time. The command was cancelled.")
         else:
-            if message.content.isdigit():
-                try:
-                    reason = preset_reasons[int(message.content) - 1]
-                except KeyError:
-                    return await ctx.send(f"{message.content} is not valid reason number. The command was cancelled.")
-            else:
-                reason = message.content  # custom reason
+            if not message.content.isdigit():
+                reason = message.content # custom reason
 
-        bot_db = await self.bot.pool.fetchval("SELECT unique_id FROM main_site_bot WHERE id = $1",
-                                              bot_user.id if bot_user else bot)
+            if message.content.isdigit():
+                reason = preset_reasons[int(message.content)-1]
+
+
+
+
+        bot_db = await self.bot.pool.fetchval("SELECT unique_id FROM main_site_bot WHERE id = $1", bot_user.id if bot_user else bot)
         await self.bot.pool.execute("DELETE FROM main_site_vote WHERE bot_id = $1", bot_db)
         await self.bot.pool.execute("DELETE FROM main_site_review WHERE bot_id = $1", bot_db)
         await self.bot.pool.execute("DELETE FROM main_site_auditlogaction WHERE bot_id = $1", bot_db)
         await self.bot.pool.execute("DELETE FROM main_site_bot WHERE id = $1", bot_user.id if bot_user else bot)
 
         embed = discord.Embed(
-            description = f"Deleted {bots['username']}", color = discord.Color.red())
-        await ctx.send(embed = embed)
+            description=f"Deleted {bots['username']}", color=discord.Color.red())
+        await ctx.send(embed=embed)
 
-        bot_owner = self.bot.main_guild.get_member(bots['main_owner'])
-        bot_owner = bot_owner if bot_owner else int(bots['main_owner'])
-        bot_member = self.bot.main_guild.get_member(bots['id']) or self.bot.verification_guild.get_member(bots['id'])
-        bot_member = bot_member if bot_member else f"{bots['username']}#{bots['discriminator']} ({bots['id']})"
-        em = bot_log_embed(ctx, (bot_member, bot_owner), reason = str(reason))
-        await self.bot.get_channel(716446098859884625).send(embed = em)
+        em = discord.Embed(
+            description=f"``{bots['username']}#{bots['discriminator']}`` by ``{ctx.guild.get_member(bots['main_owner']) or bots['main_owner']}`` was deleted by ``{ctx.author}`` for: \n```{reason}```",
+            color=discord.Color.red())
+        await self.bot.get_channel(716446098859884625).send(embed=em)
 
-        if bot_owner and bots['certified'] is True:
+        member = ctx.guild.get_member(bots['main_owner'])
+        if member and bots['certified'] is True:
             certified_dev_role = ctx.guild.get_role(716724317207003206)
-            await bot_owner.remove_roles(certified_dev_role)
+            await member.remove_roles(certified_dev_role)
 
         has_other_bots = await self.bot.pool.fetch("SELECT * FROM main_site_bot WHERE main_owner = $1",
                                                    bots['main_owner'])
-        if not has_other_bots and bot_owner:
+        if not has_other_bots and member:
             dev_role = ctx.guild.get_role(716684805286133840)
-            await bot_owner.remove_roles(dev_role)
+            await member.remove_roles(dev_role)
             await self.bot.pool.execute("UPDATE main_site_user SET developer = False WHERE id = $1",
                                         bots['main_owner'])
 
         if bot_user is not None:
-            await bot_user.kick(reason = "Bot Deleted")
+            await bot_user.kick(reason="Bot Deleted")
 
-    @commands.has_permissions(kick_members = True)
+    @commands.has_permissions(kick_members=True)
     @commands.command()
     async def say(self, ctx, *, msg: commands.clean_content):
         """Make blist repeat what you said"""
         await ctx.send(msg)
 
-    @flags.add_flag("--to", type = str, default = "en")
-    @flags.add_flag("--from", type = str, default = "auto")
-    @flags.add_flag("message", nargs = "+")
-    @commands.has_permissions(kick_members = True)
-    @commands.command(hidden = True, aliases = ["t"], cls = flags.FlagCommand)
+    @flags.add_flag("--to", type=str, default="en")
+    @flags.add_flag("--from", type=str, default="auto")
+    @flags.add_flag("message", nargs="+")
+    @commands.has_permissions(kick_members=True)
+    @commands.command(hidden=True, aliases=["t"], cls=flags.FlagCommand)
     async def translate(self, ctx, **arguments):
         """
         Translates a message to English (default) using Google translate.
@@ -366,20 +308,20 @@ class Staff(commands.Cog):
         message = ' '.join(arguments['message'])
         try:
             translated = self.translator.translate(
-                message, dest = arguments['to'], src = arguments['from'])
+                message, dest=arguments['to'], src=arguments['from'])
         except ValueError:
             return await ctx.send(
-                embed = discord.Embed(description = "That is not a valid language!", color = discord.Color.red()))
+                embed=discord.Embed(description="That is not a valid language!", color=discord.Color.red()))
 
         src = googletrans.LANGUAGES.get(
             translated.src, '(auto-detected)').title()
         dest = googletrans.LANGUAGES.get(translated.dest, 'Unknown').title()
-        embed = discord.Embed(color = discord.Color.blurple())
-        embed.add_field(name = f"{src} ({translated.src})",
-                        value = translated.origin, inline = False)
-        embed.add_field(name = f"{dest} ({translated.dest})",
-                        value = translated.text, inline = False)
-        await ctx.send(embed = embed)
+        embed = discord.Embed(color=discord.Color.blurple())
+        embed.add_field(name=f"{src} ({translated.src})",
+                        value=translated.origin, inline=False)
+        embed.add_field(name=f"{dest} ({translated.dest})",
+                        value=translated.text, inline=False)
+        await ctx.send(embed=embed)
 
     @commands.command()
     async def staff(self, ctx, member: discord.Member = None):
@@ -391,8 +333,8 @@ class Staff(commands.Cog):
             return await ctx.send("This user is not staff!")
         query = query[0]
         embed = discord.Embed(
-            color = discord.Color.blurple(),
-            description = wrap(
+            color=discord.Color.blurple(),
+            description=wrap(
                 f"""
                 >>> Staff Since: ``{query['joinedat'].strftime("%F")}``
                 Bots Approved: ``{query['approved']}``
@@ -403,12 +345,12 @@ class Staff(commands.Cog):
                 """
             )
         )
-        embed.set_author(name = member, icon_url = str(member.avatar_url))
-        await ctx.send(embed = embed)
+        embed.set_author(name=member, icon_url=str(member.avatar_url))
+        await ctx.send(embed=embed)
 
     @commands.has_permissions(kick_members = True)
     @checks.verification_guild_only()
-    @commands.command(aliases = ['lock'])
+    @commands.command()
     async def hold(self, ctx, message: typing.Optional[discord.Message] = None, *, reason: str):
         """ Waiting on a bot owner to fix their bot? Use this!
         You can also include the message url of the message to the owner like so, `b!hold URLHERE reason here`
@@ -419,55 +361,42 @@ class Staff(commands.Cog):
             colour = discord.Color.blurple(),
             timestamp = ctx.message.created_at
         )
-        em.set_author(name = ctx.author.name, icon_url = ctx.author.avatar_url)
+        em.set_author(name=ctx.author.name, icon_url=ctx.author.avatar_url)
         if message:
             em.description = f"[message link]({message.jump_url})"
 
-        staff_role = ctx.channel.category.overwrites_for(ctx.guild.get_role(763177553636098082))
-        staff_role.send_messages = False
-        everyone = ctx.channel.category.overwrites_for(ctx.guild.default_role)
-        everyone.send_messages = False
-        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = staff_role,
+        others = discord.PermissionOverwrite(send_messages = False)
+        author = discord.PermissionOverwrite(send_messages = True)
+        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = others,
                                                    reason = f"hold review for {reason}")
-        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = everyone,
+        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = others,
                                                    reason = f"hold review for {reason}")
-        await ctx.channel.category.set_permissions(ctx.author, reason = f"hold review for {reason}",
-                                                   send_messages = True)
+        await ctx.channel.category.set_permissions(ctx.author, overwrite = author,
+                                                   reason = f"hold review for {reason}")
 
-        msg = await ctx.send(embed = em)
+        msg = await ctx.send(embed=em)
         await ctx.message.delete()
         await msg.pin()
 
     @commands.has_permissions(kick_members = True)
     @checks.verification_guild_only()
-    @commands.command(aliases = ['unlock'])
-    async def unhold(self, ctx):
-        """Unhold the channel to start reviewing a bot again."""
+    @commands.command()
+    async def unlock(self, ctx):
+        """Unlock the channel to start reviewing a bot again."""
         em = discord.Embed(
             title = "Unlocked the channel, you can continue.",
             colour = discord.Color.blurple()
         )
         em.set_author(name = ctx.author.name, icon_url = ctx.author.avatar_url)
 
-        staff_role = ctx.channel.category.overwrites_for(ctx.guild.get_role(763177553636098082))
-        staff_role.send_messages = None
-        everyone = ctx.channel.category.overwrites_for(ctx.guild.default_role)
-        everyone.send_messages = None
-        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = staff_role,
-                                                   reason = "unlocked")
-        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = everyone, reason = "unlocked")
-        await ctx.channel.category.set_permissions(ctx.author, overwrite = None, reason = "unlocked")
+        others = discord.PermissionOverwrite(send_messages = True)
+        author = discord.PermissionOverwrite(send_messages = None)
+        await ctx.channel.category.set_permissions(ctx.guild.get_role(763177553636098082), overwrite = others, reason = "unlocked")
+        await ctx.channel.category.set_permissions(ctx.guild.default_role, overwrite = others, reason = "unlocked")
+        await ctx.channel.category.set_permissions(ctx.author, overwrite = author, reason = "unlocked")
 
-        await ctx.send(embed = em)
+        await ctx.send(embed=em)
         await ctx.message.delete()
-        channel_pins_hold_embeds = [x for x in await ctx.channel.pins() if x.embeds and x.embeds[0].author]
-        if not channel_pins_hold_embeds:
-            return
-
-        try:
-            await channel_pins_hold_embeds[0].unpin()
-        except:
-            return
 
 
 def setup(bot):

--- a/utils/time.py
+++ b/utils/time.py
@@ -4,14 +4,12 @@ import parsedatetime as pdt
 from discord.ext import commands
 
 
-def time_took(dt: datetime.datetime, now_dt: datetime.datetime = None, only_hours = False):
-    now = now_dt or datetime.datetime.utcnow()
+def time_took(dt: datetime.datetime):
+    now = datetime.datetime.utcnow()
     delta = now - dt
     hours, remainder = divmod(int(delta.total_seconds()), 3600)
     minutes, seconds = divmod(remainder, 60)
     days, hours = divmod(hours, 24)
-    if only_hours:
-        return hours
     if days:
         fmt = '{d} days, {h} hours, {m} minutes, and {s} seconds'
     else:

--- a/utils/time.py
+++ b/utils/time.py
@@ -4,12 +4,14 @@ import parsedatetime as pdt
 from discord.ext import commands
 
 
-def time_took(dt: datetime.datetime):
-    now = datetime.datetime.utcnow()
+def time_took(dt: datetime.datetime, now_dt: datetime.datetime = None, only_hours = False):
+    now = now_dt or datetime.datetime.utcnow()
     delta = now - dt
     hours, remainder = divmod(int(delta.total_seconds()), 3600)
     minutes, seconds = divmod(remainder, 60)
     days, hours = divmod(hours, 24)
+    if only_hours:
+        return hours
     if days:
         fmt = '{d} days, {h} hours, {m} minutes, and {s} seconds'
     else:


### PR DESCRIPTION
- Add testing categories to dict in events if bot restarts and a bot is still being tested
- check_bot_testing task loop that checks every 60 minutes if a test category exists for >= 2 hours, if it does, send a message in all text channels.
- bot_log_embed function to the embeds in site-logs sent from the deny, approve and delete command, this sends a hot new embed.
- For the queue command, a warning will show if a bot is being tested for >= 6 hours
- For the queue command, warning will show if a bot is in the queue for >= 2 hours.
- Added a try except KeyError for the preset reasons for if the number isnt in the presets.
- Added aliases: `accept` to approve, `lock` to hold, `unlock` to unhold
- For the unhold command, it will now unpin the lock message if found and removes the author overwrite.
- For the hold command, permissionsa are now correctly set to existing overwrites.